### PR TITLE
modified content tests to include author

### DIFF
--- a/apps/content/models.py
+++ b/apps/content/models.py
@@ -17,7 +17,7 @@ class Article(Resource):
     long_headline = CharField(max_length=200)
     short_headline = CharField(max_length=100)
     section = ForeignKey('Section')
-    aauthor = ForeignKey(Person)
+    author = ForeignKey(Person)
     is_published = BooleanField(default=False)
     published_at = DateTimeField()
     slug = SlugField(unique=True)

--- a/apps/content/models.py
+++ b/apps/content/models.py
@@ -17,7 +17,7 @@ class Article(Resource):
     long_headline = CharField(max_length=200)
     short_headline = CharField(max_length=100)
     section = ForeignKey('Section')
-    author = ForeignKey(Person)
+    author = ForeignKey(Person, blank=True, null=True)
     is_published = BooleanField(default=False)
     published_at = DateTimeField()
     slug = SlugField(unique=True)

--- a/apps/content/models.py
+++ b/apps/content/models.py
@@ -17,7 +17,7 @@ class Article(Resource):
     long_headline = CharField(max_length=200)
     short_headline = CharField(max_length=100)
     section = ForeignKey('Section')
-    author = ForeignKey(Person)
+    aauthor = ForeignKey(Person)
     is_published = BooleanField(default=False)
     published_at = DateTimeField()
     slug = SlugField(unique=True)

--- a/apps/content/tests.py
+++ b/apps/content/tests.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.utils import timezone
 from django.db import IntegrityError
 from apps.content.models import Section, Article, Image
+from apps.core.models import Person
 
 class SectionTests(TestCase):
     NAME = "News"
@@ -17,11 +18,15 @@ class SectionTests(TestCase):
 class ArticleTests(TestCase):
     def setUp(self):
         sCulture = Section.objects.create(name="Culture")
+        author = Person.objects.create(
+            first_name="John",
+            last_name="Doe")
 
         self.A1 = {
             "long_headline": "Buchanan Tower Rated Uglier Than One Yonge Street",
             "short_headline": "BuTo Strikes Fear",
             "section": sCulture,
+            "author": author,
             "published_at": timezone.now(),
             "slug": "buto-strikes-fear",
             "content": "Refer to headline."


### PR DESCRIPTION
I added an author parameter to the article test now that the author field is implemented. This is a fix for the issue discussed in #37 -- the author field no longer has to be commented out. 
