### PR TITLE
Add ordering to homepage section articles

### DIFF
--- a/dispatch/apps/content/models.py
+++ b/dispatch/apps/content/models.py
@@ -366,7 +366,7 @@ class ArticleManager(PublishableManager):
         sections = Section.objects.all()
 
         for section in sections:
-            articles = self.exclude(id__in=frontpage).filter(section=section,is_published=True)[:5]
+            articles = self.exclude(id__in=frontpage).filter(section=section,is_published=True).order_by('-published_at')[:5]
             if len(articles) > 0:
                 results[section.slug] = {
                     'first': articles[0],


### PR DESCRIPTION
This should fix the issue with newer articles now showing up on the homepage.
