### PR TITLE
Fixes undefined object in fetch_recent_articles_fulfilled

### DIFF
--- a/dispatch/static/manager/src/js/reducers/DashboardReducer.js
+++ b/dispatch/static/manager/src/js/reducers/DashboardReducer.js
@@ -40,7 +40,7 @@ const recentReducer = (state = initialState.recent, action) => {
         isLoading: true
       })
     case `${types.FETCH_RECENT_ARTICLES}_FULFILLED`:
-      const data = Object.keys(action.payload.entities.articles).map((elem) => ({
+      const data = Object.keys(action.payload.entities.articles || {}).map((elem) => ({
         id: elem,
         headline: action.payload.entities.articles[elem].headline
       }));


### PR DESCRIPTION
fixes #481.

Added a fallback to the Object.keys call so if no articles exist it will call Object.keys with an {} instead of undefined.