### PR TITLE
#560 itemlist headers

### DIFF
--- a/dispatch/static/manager/src/js/components/Header.js
+++ b/dispatch/static/manager/src/js/components/Header.js
@@ -17,7 +17,7 @@ export default function Header(props) {
 
   return (
     <header className='c-header'>
-      <div className='c-header__inner u-container'>
+      <div className='c-header__inner'>
         <Link to='/' className='c-header__logo'>dispatch</Link>
         <nav className='c-header__sections'>
           <ul>{sections}</ul>

--- a/dispatch/static/manager/src/js/components/ItemList/ItemListColumnHeaders.js
+++ b/dispatch/static/manager/src/js/components/ItemList/ItemListColumnHeaders.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import R from 'ramda'
+
+export default function ItemListColumnHeaders(props) {
+  if (!props.headers) {
+    return null
+  }
+
+  // blank first column for checkbox
+  const headers = R.insert(0, '', props.headers)
+
+  const items = headers.map((elem, i) => {
+    return (
+      <div key={i} className='c-item-list__item__cell'>
+        {elem}
+      </div>
+    )
+  })
+
+  return (
+    <li className='c-item-list__item c-item-list__column__header'>
+      {items}
+    </li>
+  )
+}

--- a/dispatch/static/manager/src/js/components/ItemList/ItemListColumnHeaders.js
+++ b/dispatch/static/manager/src/js/components/ItemList/ItemListColumnHeaders.js
@@ -1,17 +1,13 @@
 import React from 'react'
-import R from 'ramda'
 
 export default function ItemListColumnHeaders(props) {
   if (!props.headers) {
     return null
   }
 
-  // blank first column for checkbox
-  const headers = R.insert(0, '', props.headers)
-
-  const items = headers.map((elem, i) => {
+  const items = props.headers.map((elem, i) => {
     return (
-      <div key={i} className='c-item-list__item__cell'>
+      <div key={i+1} className='c-item-list__item__cell'>
         {elem}
       </div>
     )
@@ -19,6 +15,7 @@ export default function ItemListColumnHeaders(props) {
 
   return (
     <li className='c-item-list__item c-item-list__column-headers'>
+      <div key={0} className='c-item-list__item__cell' />
       {items}
     </li>
   )

--- a/dispatch/static/manager/src/js/components/ItemList/ItemListColumnHeaders.js
+++ b/dispatch/static/manager/src/js/components/ItemList/ItemListColumnHeaders.js
@@ -18,7 +18,7 @@ export default function ItemListColumnHeaders(props) {
   })
 
   return (
-    <li className='c-item-list__item c-item-list__column__header'>
+    <li className='c-item-list__item c-item-list__column-headers'>
       {items}
     </li>
   )

--- a/dispatch/static/manager/src/js/components/ItemList/ItemListTable.js
+++ b/dispatch/static/manager/src/js/components/ItemList/ItemListTable.js
@@ -10,7 +10,7 @@ export default function ItemListTable(props) {
 
   if (props.items.isLoading) {
     return (
-      <div className='c-item-list__table u-container'>
+      <div className='c-item-list__table'>
         <ul>
           <ItemListItemPlaceholder />
           <ItemListItemPlaceholder />
@@ -47,7 +47,7 @@ export default function ItemListTable(props) {
     })
 
     return (
-      <div className='c-item-list__table u-container u-container--align-left'>
+      <div className='c-item-list__table'>
         <ul>
           <ItemListColumnHeaders headers={props.headers} />
           {items}

--- a/dispatch/static/manager/src/js/components/ItemList/ItemListTable.js
+++ b/dispatch/static/manager/src/js/components/ItemList/ItemListTable.js
@@ -4,6 +4,7 @@ import R from 'ramda'
 import ItemListItem from './ItemListItem'
 import ItemListItemPlaceholder from './ItemListItemPlaceholder'
 import ItemListEmpty from './ItemListEmpty'
+import ItemListColumnHeaders from './ItemListColumnHeaders'
 
 export default function ItemListTable(props) {
 
@@ -47,7 +48,10 @@ export default function ItemListTable(props) {
 
     return (
       <div className='c-item-list__table u-container u-container--align-left'>
-        <ul>{items}</ul>
+        <ul>
+          <ItemListColumnHeaders headers={props.headers} />
+          {items}
+        </ul>
       </div>
     )
   }

--- a/dispatch/static/manager/src/js/components/ItemList/index.js
+++ b/dispatch/static/manager/src/js/components/ItemList/index.js
@@ -22,6 +22,7 @@ export default function ItemList(props) {
         items={props.items}
         entities={props.entities}
         columns={props.columns}
+        headers={props.headers}
         location={props.location}
         emptyMessage={props.emptyMessage}
         createHandler={props.createHandler}

--- a/dispatch/static/manager/src/js/components/Toolbar.js
+++ b/dispatch/static/manager/src/js/components/Toolbar.js
@@ -3,11 +3,8 @@ import React from 'react'
 require('../../styles/components/toolbar.scss')
 
 export function Toolbar(props) {
-
-  const className = props.alignLeft ? 'c-toolbar u-container u-container--align-left' : 'c-toolbar u-container'
-
   return (
-    <header className={className}>{props.children}</header>
+    <header className='c-toolbar'>{props.children}</header>
   )
 }
 

--- a/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
@@ -58,7 +58,15 @@ function ArticlePageComponent(props) {
         item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
         item => item.latest_version + ' revisions'
       ]}
-
+      extraRelistCondition={(prevProps, props) => {
+        return prevProps.location.query.section !== props.location.query.section
+      }}
+      extraQueryHandler={(query, props) => {
+        if (props.location.query.section) {
+          query.section = props.location.query.section
+        }
+        return query
+      }}
       {...props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
@@ -58,10 +58,10 @@ function ArticlePageComponent(props) {
         item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
         item => item.latest_version + ' revisions'
       ]}
-      extraRelistCondition={(prevProps, props) => {
+      shouldReload={(prevProps, props) => {
         return prevProps.location.query.section !== props.location.query.section
       }}
-      extraQueryHandler={(query, props) => {
+      queryHandler={(query, props) => {
         if (props.location.query.section) {
           query.section = props.location.query.section
         }

--- a/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
@@ -1,156 +1,16 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import DocumentTitle from 'react-document-title'
 
-import { Link } from 'react-router'
-
-import { Intent } from '@blueprintjs/core'
-
+import ItemIndexPage from '../ItemIndexPage'
 import articlesActions from '../../actions/ArticlesActions'
 import { humanizeDatetime } from '../../util/helpers'
-
-import { LinkButton } from '../../components/inputs'
-import ItemList from '../../components/ItemList'
-
-const DEFAULT_LIMIT = 15
-
-class ArticlesPageComponent extends React.Component {
-
-  constructor(props) {
-    super(props)
-
-    this.handleDeleteArticles = this.handleDeleteArticles.bind(this)
-    this.handleSearchArticles = this.handleSearchArticles.bind(this)
-  }
-
-  getQuery() {
-    var query = {
-      limit: DEFAULT_LIMIT,
-      drafts: true,
-      offset: (this.getCurrentPage() - 1) * DEFAULT_LIMIT
-    }
-
-    // If section is present, add to query
-    if (this.props.location.query.section) {
-      query.section = this.props.location.query.section
-    }
-
-    // If search query is present, add to query
-    if (this.props.location.query.q) {
-      query.q = this.props.location.query.q
-    }
-
-    return query
-  }
-
-  getCurrentPage() {
-    return parseInt(this.props.location.query.page, 10) || 1
-  }
-
-  getTotalPages() {
-    return Math.ceil(
-      parseInt(this.props.articles.count, 10) / DEFAULT_LIMIT
-    )
-  }
-
-  componentWillMount() {
-    // Fetch articles
-    this.props.clearArticles()
-    this.props.clearSelectedArticles()
-    this.props.listArticles(this.props.token, this.getQuery())
-  }
-
-  componentDidUpdate(prevProps) {
-
-    if (this.isNewSection(prevProps, this.props) || this.isNewQuery(prevProps, this.props)) {
-      this.props.clearArticles()
-      this.props.clearSelectedArticles()
-      this.props.listArticles(this.props.token, this.getQuery())
-    }
-
-    else if (this.isNewPage(prevProps, this.props)) {
-      // Fetch articles
-      this.props.listArticles(this.props.token, this.getQuery())
-      this.props.clearSelectedArticles()
-    }
-  }
-
-  isNewSection(prevProps, props) {
-    // Returns true if section has changed
-    return prevProps.location.query.section !== props.location.query.section
-  }
-
-  isNewQuery(prevProps, props) {
-    return prevProps.location.query.q !== props.location.query.q
-  }
-
-  isNewPage(prevProps, props) {
-    // Returns true if page number has changed
-    return prevProps.location.query.page !== props.location.query.page
-  }
-
-  handleDeleteArticles(articleIds) {
-    this.props.deleteArticles(this.props.token, articleIds)
-    this.props.clearSelectedArticles()
-  }
-
-  handleSearchArticles(query) {
-    this.props.searchArticles(this.props.token, this.props.location.query.section, query)
-  }
-
-  render() {
-    const section = this.props.entities.sections[this.props.location.query.section]
-    const title = section ? `${section.name} - Articles` : 'Articles'
-
-    return (
-      <DocumentTitle title={title}>
-        <ItemList
-          location={this.props.location}
-
-          typePlural='articles'
-          typeSingular='article'
-
-          currentPage={this.getCurrentPage()}
-          totalPages={this.getTotalPages()}
-
-          items={this.props.articles}
-          entities={this.props.entities.articles}
-
-          columns={[
-            item => (<strong><Link to={`/articles/${item.id}`} dangerouslySetInnerHTML={{__html: item.headline}} /></strong>),
-            item => item.authors_string,
-            item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
-            item => item.latest_version + ' revisions'
-          ]}
-
-
-          emptyMessage={'You haven\'t created any articles yet.'}
-          createHandler={() => (
-            <LinkButton intent={Intent.SUCCESS} to={'articles/new'}>
-              <span className='pt-icon-standard pt-icon-add'></span>Create article
-            </LinkButton>)
-          }
-
-          actions={{
-            toggleItem: this.props.toggleArticle,
-            toggleAllItems: this.props.toggleAllArticles,
-            deleteItems: this.handleDeleteArticles,
-            searchItems: this.handleSearchArticles
-          }}
-
-          />
-      </DocumentTitle>
-    )
-  }
-
-}
 
 const mapStateToProps = (state) => {
   return {
     token: state.app.auth.token,
-    articles: state.app.articles.list,
+    listItems: state.app.articles.list,
     entities: {
-      articles: state.app.entities.articles,
+      listItems: state.app.entities.articles,
       sections: state.app.entities.sections
     }
   }
@@ -158,33 +18,55 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    listArticles: (token, query) => {
+    listListItems: (token, query) => {
       dispatch(articlesActions.list(token, query))
     },
-    toggleArticle: (articleId) => {
+    toggleListItem: (articleId) => {
       dispatch(articlesActions.toggle(articleId))
     },
-    toggleAllArticles: (articleIds) => {
+    toggleAllListItems: (articleIds) => {
       dispatch(articlesActions.toggleAll(articleIds))
     },
-    clearSelectedArticles: () => {
+    clearSelectedListItems: () => {
       dispatch(articlesActions.clearSelected())
     },
-    clearArticles: () => {
+    clearListItems: () => {
       dispatch(articlesActions.clearAll())
     },
-    deleteArticles: (token, articleIds) => {
+    deleteListItems: (token, articleIds) => {
       dispatch(articlesActions.deleteMany(token, articleIds))
     },
-    searchArticles: (token, section, query) => {
+    searchListItems: (token, section, query) => {
       dispatch(articlesActions.search(section, query))
     }
   }
 }
 
+function ArticlePageComponent(props) {
+  const section = props.entities.sections[props.location.query.section]
+  const title = section ? `${section.name} - Articles` : 'Articles'
+
+  return (
+    <ItemIndexPage
+      pageTitle={title}
+      typePlural='articles'
+      typeSingular='article'
+      displayColumn='headline'
+      headers={[ 'Headline', 'Authors', 'Published', 'Revisions']}
+      extraColumns={[
+        item => item.authors_string,
+        item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
+        item => item.latest_version + ' revisions'
+      ]}
+
+      {...props} />
+  )
+}
+
+
 const ArticlesPage = connect(
   mapStateToProps,
   mapDispatchToProps
-)(ArticlesPageComponent)
+)(ArticlePageComponent)
 
 export default ArticlesPage

--- a/dispatch/static/manager/src/js/pages/Galleries/GalleryIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Galleries/GalleryIndexPage.js
@@ -56,6 +56,7 @@ function GalleryPageComponent(props) {
       typeSingular='gallery'
       typePlural='galleries'
       displayColumn='title'
+      headers={[ 'Title' ]}
       {... props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Galleries/GalleryIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Galleries/GalleryIndexPage.js
@@ -56,6 +56,7 @@ function GalleryPageComponent(props) {
       typeSingular='gallery'
       typePlural='galleries'
       displayColumn='title'
+      pageTitle='Galleries'
       headers={[ 'Title' ]}
       {... props} />
   )

--- a/dispatch/static/manager/src/js/pages/ItemIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/ItemIndexPage.js
@@ -25,9 +25,7 @@ export default class ListItemsPageComponent extends React.Component {
       query.listItem = this.props.location.query.listItem
     }
 
-    if (typeof this.props.extraQueryHandler === 'function') {
-      query = this.props.extraQueryHandler(query, this.props)
-    }
+    query = this.props.queryHandler(query, this.props)
 
     // If search query is present, add to query
     if (this.props.location.query.q) {
@@ -54,17 +52,10 @@ export default class ListItemsPageComponent extends React.Component {
     this.props.listListItems(this.props.token, this.getQuery())
   }
 
-  extraRelistCondition(prevProps, props) {
-    if (typeof this.props.extraRelistCondition !== 'function') {
-      return false
-    }
-    return this.props.extraRelistCondition(prevProps, props)
-  }
-
   componentDidUpdate(prevProps) {
 
     if (this.isNewQuery(prevProps, this.props)
-      || this.extraRelistCondition(prevProps, this.props)) {
+      || this.props.shouldReload(prevProps, this.props)) {
       this.props.clearListItems()
       this.props.clearSelectedListItems()
       this.props.listListItems(this.props.token, this.getQuery())
@@ -147,5 +138,12 @@ export default class ListItemsPageComponent extends React.Component {
 }
 
 ListItemsPageComponent.propTypes = {
-  pageTitle: PropTypes.string.isRequired
+  pageTitle: PropTypes.string.isRequired,
+  shouldReload: PropTypes.func,
+  queryHandler: PropTypes.func
+}
+
+ListItemsPageComponent.defaultProps = {
+  shouldReload: () => { false },
+  queryHandler: (query) => { query }
 }

--- a/dispatch/static/manager/src/js/pages/ItemIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/ItemIndexPage.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import R from 'ramda'
 import DocumentTitle from 'react-document-title'
 
@@ -22,6 +23,10 @@ export default class ListItemsPageComponent extends React.Component {
     // If listItem is present, add to query
     if (this.props.location.query.listItem) {
       query.listItem = this.props.location.query.listItem
+    }
+
+    if (typeof this.props.extraQueryHandler === 'function') {
+      query = this.props.extraQueryHandler(query, this.props)
     }
 
     // If search query is present, add to query
@@ -49,9 +54,17 @@ export default class ListItemsPageComponent extends React.Component {
     this.props.listListItems(this.props.token, this.getQuery())
   }
 
+  extraRelistCondition(prevProps, props) {
+    if (typeof this.props.extraRelistCondition !== 'function') {
+      return false
+    }
+    return this.props.extraRelistCondition(prevProps, props)
+  }
+
   componentDidUpdate(prevProps) {
 
-    if (this.isNewQuery(prevProps, this.props)) {
+    if (this.isNewQuery(prevProps, this.props)
+      || this.extraRelistCondition(prevProps, this.props)) {
       this.props.clearListItems()
       this.props.clearSelectedListItems()
       this.props.listListItems(this.props.token, this.getQuery())
@@ -84,10 +97,6 @@ export default class ListItemsPageComponent extends React.Component {
   }
 
   render() {
-    const titleString = this.props.pageTitle
-      // Make the title start with uppercase letter
-      || this.props.typePlural.replace(/^\w/, m => m.toUpperCase())
-
     // The first column will always be a link, as defined here,
     // containing the item property associated with displayColumn
     const columns = R.insert(0, item => (
@@ -100,7 +109,7 @@ export default class ListItemsPageComponent extends React.Component {
     ), this.props.extraColumns || [])
 
     return (
-      <DocumentTitle title={titleString}>
+      <DocumentTitle title={this.props.pageTitle}>
         <ItemList
           location={this.props.location}
 
@@ -135,4 +144,8 @@ export default class ListItemsPageComponent extends React.Component {
     )
   }
 
+}
+
+ListItemsPageComponent.propTypes = {
+  pageTitle: PropTypes.string.isRequired
 }

--- a/dispatch/static/manager/src/js/pages/ItemIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/ItemIndexPage.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import R from 'ramda'
 import DocumentTitle from 'react-document-title'
 
 import { Link } from 'react-router'
@@ -86,6 +87,17 @@ export default class ListItemsPageComponent extends React.Component {
     // Make the title start with uppercase letter
     const titleString = this.props.typePlural.replace(/^\w/, m => m.toUpperCase())
 
+    // The first column will always be a link, as defined here,
+    // containing the item property associated with displayColumn
+    const columns = R.insert(0, item => (
+      <strong>
+        <Link
+          to={`/${this.props.typePlural}/${item.id}`}
+          dangerouslySetInnerHTML={{__html: item[this.props.displayColumn] || item.name}} />
+      </strong>
+    // extraColumns are after the main link column
+    ), this.props.extraColumns || [])
+
     return (
       <DocumentTitle title={titleString}>
         <ItemList
@@ -100,10 +112,8 @@ export default class ListItemsPageComponent extends React.Component {
           items={this.props.listItems}
           entities={this.props.entities.listItems}
 
-          columns={[
-            item => (<strong><Link to={`/${this.props.typePlural}/${item.id}`} dangerouslySetInnerHTML={{__html: item[this.props.displayColumn] || item.name}} /></strong>),
-            item => item.slug
-          ]}
+          columns={columns}
+          headers={this.props.headers}
 
           emptyMessage={`You haven\'t created any ${this.props.typePlural} yet.`}
           createHandler={() => (

--- a/dispatch/static/manager/src/js/pages/ItemIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/ItemIndexPage.js
@@ -84,8 +84,9 @@ export default class ListItemsPageComponent extends React.Component {
   }
 
   render() {
-    // Make the title start with uppercase letter
-    const titleString = this.props.typePlural.replace(/^\w/, m => m.toUpperCase())
+    const titleString = this.props.pageTitle
+      // Make the title start with uppercase letter
+      || this.props.typePlural.replace(/^\w/, m => m.toUpperCase())
 
     // The first column will always be a link, as defined here,
     // containing the item property associated with displayColumn

--- a/dispatch/static/manager/src/js/pages/Pages/PageIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Pages/PageIndexPage.js
@@ -47,6 +47,7 @@ function PagesPageComponent(props) {
       typePlural='pages'
       typeSingular='page'
       displayColumn='title'
+      pageTitle='Pages'
       headers={[ 'Title', 'Published', 'Revisions' ]}
       extraColumns={[
         item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',

--- a/dispatch/static/manager/src/js/pages/Pages/PageIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Pages/PageIndexPage.js
@@ -1,163 +1,59 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import DocumentTitle from 'react-document-title'
 
-import { Link } from 'react-router'
-import { Intent } from '@blueprintjs/core'
-
+import ItemIndexPage from '../ItemIndexPage'
 import pagesActions from '../../actions/PagesActions'
 import { humanizeDatetime } from '../../util/helpers'
-
-import { LinkButton } from '../../components/inputs'
-import ItemList from '../../components/ItemList'
-
-const DEFAULT_LIMIT = 15
-
-class PagesPageComponent extends React.Component {
-
-  getQuery() {
-    var query = {
-      limit: DEFAULT_LIMIT,
-      drafts: true,
-      offset: (this.getCurrentPage() - 1) * DEFAULT_LIMIT
-    }
-
-    // If section is present, add to query
-    if (this.props.location.query.section) {
-      query.section = this.props.location.query.section
-    }
-
-    // If search query is present, add to query
-    if (this.props.location.query.q) {
-      query.q = this.props.location.query.q
-    }
-
-    return query
-  }
-
-  getCurrentPage() {
-    return parseInt(this.props.location.query.page, 10) || 1
-  }
-
-  getTotalPages() {
-    return Math.ceil(
-      parseInt(this.props.pages.count, 10) / DEFAULT_LIMIT
-    )
-  }
-
-  componentWillMount() {
-    // Fetch pages
-    this.props.clearPages()
-    this.props.clearSelectedPages()
-    this.props.listPages(this.props.token, this.getQuery())
-  }
-
-  componentDidUpdate(prevProps) {
-
-    if (this.isNewQuery(prevProps, this.props)) {
-      this.props.clearPages()
-      this.props.clearSelectedPages()
-      this.props.listPages(this.props.token, this.getQuery())
-    }
-
-    else if (this.isNewPage(prevProps, this.props)) {
-      // Fetch pages
-      this.props.listPages(this.props.token, this.getQuery())
-      this.props.clearSelectedPages()
-    }
-  }
-
-  isNewQuery(prevProps, props) {
-    return prevProps.location.query.q !== props.location.query.q
-  }
-
-  isNewPage(prevProps, props) {
-    // Returns true if page number has changed
-    return prevProps.location.query.page !== props.location.query.page
-  }
-
-  deletePages(pageIds) {
-    this.props.deletePages(this.props.token, pageIds)
-    this.props.clearSelectedPages()
-  }
-
-  searchPages(query) {
-    this.props.searchPages(this.props.token, this.props.location.query.section, query)
-  }
-
-  render() {
-
-    return (
-      <DocumentTitle title='Pages'>
-        <ItemList
-          location={this.props.location}
-
-          typePlural='pages'
-          typeSingular='page'
-
-          currentPage={this.getCurrentPage()}
-          totalPages={this.getTotalPages()}
-
-          items={this.props.pages}
-          entities={this.props.entities.pages}
-
-          columns={[
-            item => (<strong><Link to={`/pages/${item.id}`} dangerouslySetInnerHTML={{__html: item.title}} /></strong>),
-            item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
-            item => item.latest_version + ' revisions'
-          ]}
-
-          emptyMessage={'You haven\'t created any pages yet.'}
-          createHandler={() => (<LinkButton intent={Intent.SUCCESS} to={'pages/new'}>Create page</LinkButton>)}
-
-          actions={{
-            toggleItem: this.props.togglePage,
-            toggleAllItems: this.props.toggleAllPages,
-            deleteItems: (pageIds) => this.deletePages(pageIds),
-            searchItems: (query) => this.searchPages(query)
-          }}
-
-          />
-      </DocumentTitle>
-    )
-  }
-
-}
 
 const mapStateToProps = (state) => {
   return {
     token: state.app.auth.token,
-    pages: state.app.pages.list,
+    listItems: state.app.pages.list,
     entities: {
-      pages: state.app.entities.pages
+      listItems: state.app.entities.pages
     }
   }
 }
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    listPages: (token, query) => {
+    listListItems: (token, query) => {
       dispatch(pagesActions.list(token, query))
     },
-    togglePage: (pageId) => {
+    toggleListItem: (pageId) => {
       dispatch(pagesActions.toggle(pageId))
     },
-    toggleAllPages: (pageIds) => {
+    toggleAllListItems: (pageIds) => {
       dispatch(pagesActions.toggleAll(pageIds))
     },
-    clearSelectedPages: () => {
+    clearSelectedListItems: () => {
       dispatch(pagesActions.clearSelected())
     },
-    clearPages: () => {
+    clearListItems: () => {
       dispatch(pagesActions.clearAll())
     },
-    deletePages: (token, pageIds) => {
+    deleteListItems: (token, pageIds) => {
       dispatch(pagesActions.deleteMany(token, pageIds))
     },
-    searchPages: (token, section, query) => {
+    searchListItems: (token, section, query) => {
       dispatch(pagesActions.search(section, query))
     }
   }
+}
+
+function PagesPageComponent(props) {
+  return (
+    <ItemIndexPage
+      typePlural='pages'
+      typeSingular='page'
+      displayColumn='title'
+      headers={[ 'Title', 'Published', 'Revisions' ]}
+      extraColumns={[
+        item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
+        item => item.latest_version + ' revisions'
+      ]}
+      {...props} />
+  )
 }
 
 const PagesPage = connect(

--- a/dispatch/static/manager/src/js/pages/Persons/PersonIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Persons/PersonIndexPage.js
@@ -55,6 +55,10 @@ function PersonsPageComponent(props) {
       typeSingular='person'
       typePlural='persons'
       displayColumn='full_name'
+      headers={[ 'Full Name', 'Slug' ]}
+      extraColumns={[
+        item => item.slug
+      ]}
       {... props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Persons/PersonIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Persons/PersonIndexPage.js
@@ -55,6 +55,7 @@ function PersonsPageComponent(props) {
       typeSingular='person'
       typePlural='persons'
       displayColumn='full_name'
+      pageTitle='Persons'
       headers={[ 'Full Name', 'Slug' ]}
       extraColumns={[
         item => item.slug

--- a/dispatch/static/manager/src/js/pages/Sections/SectionIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Sections/SectionIndexPage.js
@@ -55,6 +55,7 @@ function SectionsPageComponent(props) {
       typeSingular='section'
       typePlural='sections'
       displayColumn='name'
+      pageTitle='Sections'
       headers={[ 'Name', 'Slug' ]}
       extraColumns={[
         item => item.slug

--- a/dispatch/static/manager/src/js/pages/Sections/SectionIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Sections/SectionIndexPage.js
@@ -54,6 +54,11 @@ function SectionsPageComponent(props) {
     <ItemIndexPage
       typeSingular='section'
       typePlural='sections'
+      displayColumn='name'
+      headers={[ 'Name', 'Slug' ]}
+      extraColumns={[
+        item => item.slug
+      ]}
       {... props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Tags/TagIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Tags/TagIndexPage.js
@@ -55,6 +55,8 @@ function TagsPageComponent(props) {
     <ItemIndexPage
       typeSingular='tag'
       typePlural='tags'
+      displayColumn='name'
+      headers={[ 'Name' ]}
       {... props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Tags/TagIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Tags/TagIndexPage.js
@@ -56,6 +56,7 @@ function TagsPageComponent(props) {
       typeSingular='tag'
       typePlural='tags'
       displayColumn='name'
+      pageTitle='Tags'
       headers={[ 'Name' ]}
       {... props} />
   )

--- a/dispatch/static/manager/src/js/pages/Topics/TopicIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Topics/TopicIndexPage.js
@@ -54,6 +54,8 @@ function TopicsPageComponent(props) {
     <ItemIndexPage
       typeSingular='topic'
       typePlural='topics'
+      displayColumn='name'
+      headers={[ 'Name' ]}
       {... props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Topics/TopicIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Topics/TopicIndexPage.js
@@ -55,6 +55,7 @@ function TopicsPageComponent(props) {
       typeSingular='topic'
       typePlural='topics'
       displayColumn='name'
+      pageTitle='Topics'
       headers={[ 'Name' ]}
       {... props} />
   )

--- a/dispatch/static/manager/src/styles/components/header.scss
+++ b/dispatch/static/manager/src/styles/components/header.scss
@@ -5,6 +5,8 @@
 // Component: Header
 .c-header {
   // Structure
+  padding-left: 1rem;
+  padding-right: 1rem;
   box-sizing: border-box;
 
   // Background
@@ -44,7 +46,6 @@
   height: 40px;
   padding-left: 1rem;
   padding-right: 1rem;
-  margin-left: -1rem;
   margin-right: 1rem;
 
   // Text

--- a/dispatch/static/manager/src/styles/components/item_list.scss
+++ b/dispatch/static/manager/src/styles/components/item_list.scss
@@ -154,7 +154,7 @@
 
 // Component: ItemListColumnHeader
 .c-item-list__column__header {
-  font-weight: 700;
+  font-weight: 600;
 }
 
 .c-item-list__column__header > .c-item-list__item__cell {

--- a/dispatch/static/manager/src/styles/components/item_list.scss
+++ b/dispatch/static/manager/src/styles/components/item_list.scss
@@ -22,6 +22,17 @@
   }
 }
 
+// Component: ItemListColumnHeaders
+.c-item-list__column-headers {
+  // Text
+  font-weight: $font-weight-semi-bold;
+}
+
+.c-item-list__column-headers > .c-item-list__item__cell {
+  // Border
+  border-bottom: 1px solid $color-border-gray;
+}
+
 .c-item-list__item {
   display: table-row;
 }
@@ -36,10 +47,8 @@
   color: $color-text-gray;
 
   &--checkbox {
-    width: 3rem;
-    text-align: center;
-    padding-left: 0;
-    margin-left: -1rem;
+    width: 4rem;
+    padding-left: 2rem;
   }
 
   &--title {
@@ -78,12 +87,8 @@
 .c-item-list__header__checkbox {
   // Structure
   display: inline-block;
-  width: 3rem;
-  padding-left: 0;
+  width: 2rem;
   margin-right: 7px;
-
-  // Text
-  text-align: center;
 }
 
 .c-item-list__header__delete {
@@ -150,14 +155,4 @@
     margin-bottom: 1em;
     @include font-size(20);
   }
-}
-
-// Component: ItemListColumnHeader
-.c-item-list__column__header {
-  font-weight: 600;
-}
-
-.c-item-list__column__header > .c-item-list__item__cell {
-  border-bottom-color: #aaa;
-  border-bottom-width: 1px;
 }

--- a/dispatch/static/manager/src/styles/components/item_list.scss
+++ b/dispatch/static/manager/src/styles/components/item_list.scss
@@ -151,3 +151,13 @@
     @include font-size(20);
   }
 }
+
+// Component: ItemListColumnHeader
+.c-item-list__column__header {
+  font-weight: 700;
+}
+
+.c-item-list__column__header > .c-item-list__item__cell {
+  border-bottom-color: #aaa;
+  border-bottom-width: 1px;
+}

--- a/dispatch/static/manager/src/styles/components/toolbar.scss
+++ b/dispatch/static/manager/src/styles/components/toolbar.scss
@@ -6,6 +6,8 @@
   display: flex;
   overflow: hidden;
   height: 50px;
+  padding-left: 2rem;
+  padding-right: 2rem;
 
   // Border
   border-bottom: thin solid $color-border-gray;
@@ -18,8 +20,14 @@
   font-size: 14px;
   line-height: 48px;
 
-  .pt-button {
+  > .pt-button {
+    // Structure
     margin-right: 0.75rem;
+
+    &:last-child {
+      // Structure
+      margin-right: 0;
+    }
   }
 }
 

--- a/dispatch/static/manager/yarn.lock
+++ b/dispatch/static/manager/yarn.lock
@@ -3205,7 +3205,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.8:
+prop-types@^15.5.4, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
- Allow configurable column headers are configured in itemlist. 
- configure all pages using itemlist to have appropriate headers.
- (events will need to be updated to have headers following merge)
- The Article and Page index pages weren't using the reusable itemlist component. Now they do.

