### PR TITLE
patch event view set to allow updating is_submission

### DIFF
--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -423,9 +423,9 @@ class EventViewSet(DispatchModelViewSet):
                 Q(category__iexact=q)
             )
 
-        if pending:
+        if pending == '1':
             queryset = queryset.filter(is_submission=True)
-        else:
+        elif pending == '0':
             queryset = queryset.filter(is_submission=False)
 
         return queryset

--- a/dispatch/static/manager/src/js/pages/Events/EventIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Events/EventIndexPage.js
@@ -19,6 +19,10 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     listListItems: (token, query) => {
+      if (!query) {
+        query = {}
+      }
+      query.pending = 0
       dispatch(eventsActions.list(token, query))
     },
     toggleListItem: (eventId) => {
@@ -45,6 +49,10 @@ const mapDispatchToProps = (dispatch) => {
       }
     },
     searchListItems: (query) => {
+      if (!query) {
+        query = {}
+      }
+      query.pending = 0
       dispatch(eventsActions.search(query))
     }
   }

--- a/dispatch/tests/test_api_events.py
+++ b/dispatch/tests/test_api_events.py
@@ -182,7 +182,7 @@ class EventTests(DispatchAPITestCase, DispatchMediaTestMixin):
         url_2 = '%s?q=%s' % (reverse('api-event-list'), 'UBC')
         url_3 = '%s?q=%s' % (reverse('api-event-list'), 'String Theory')
         url_4 = '%s?pending=1' % reverse('api-event-list')
-        url_5 = '%s?q=%s' % (reverse('api-event-list'), 'Ubyssey')
+        url_5 = '%s?q=%s&pending=0' % (reverse('api-event-list'), 'Ubyssey')
         url_6 = '%s?q=%s' % (reverse('api-event-list'), 'music')
         url_7 = '%s?q=%s' % (reverse('api-event-list'), 'Music')
 
@@ -284,3 +284,20 @@ class EventTests(DispatchAPITestCase, DispatchMediaTestMixin):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['image'], None)
+
+    def test_approve_event(self):
+        """Should be able change is_submission=1 to 0"""
+
+        event = DispatchTestHelpers.create_event(self.client, title='This is a user submission', host='Ubyssey', is_submission=True)
+
+        self.assertEqual(event.data['is_submission'], True)
+
+        data = {
+            'is_submission': False
+        }
+
+        url = reverse('api-event-detail', args=[event.data['id']])
+
+        updated_event = self.client.patch(url, data, format='json')
+
+        self.assertEqual(updated_event.data['is_submission'], False)


### PR DESCRIPTION
also add test case

it changes the spec so that if an authenticated user lists events, they get pending=0&1, unless they specify pending.

makes it much easier to PATCH is_submission