### PR TITLE
Fixed issue

### DIFF
--- a/dispatch/static/manager/src/js/pages/Events/EventAuditPage.js
+++ b/dispatch/static/manager/src/js/pages/Events/EventAuditPage.js
@@ -104,7 +104,7 @@ class EventAuditPage extends React.Component {
             <ToolbarRight>
               <ItemListPagination
                 currentPage={parseInt(this.props.location.query.page || 1, 10)}
-                totalPages={Math.ceil(this.props.events.count / PER_PAGE)}
+                totalPages={Math.ceil(this.props.events.count / PER_PAGE) !== 0 ? Math.ceil(this.props.events.count / PER_PAGE) : 1}
                 location={this.props.location} />
             </ToolbarRight>
           </Toolbar>


### PR DESCRIPTION
issue #606: Can solve by doing if-else, or by doing `totalPages={Math.ceil(this.props.events.count / PER_PAGE + 0.1)}`. I assumed that the if-else would be preferred, but let me know if we want to keep it shorter!