### PR TITLE
widgets fixes

### DIFF
--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -15,7 +15,7 @@ def zone(zone_id):
 
     try:
         return zone.widget.render()
-    except WidgetNotFound:
+    except (WidgetNotFound, AttributeError):
         pass
 
     return ''

--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -1,4 +1,3 @@
-
 from django import template
 
 from dispatch.theme import ThemeManager
@@ -14,8 +13,7 @@ def zone(zone_id):
     except ZoneNotFound:
         return ''
 
-    widget = zone.widget
-    if widget is not None:
-        return widget.render()
+    if zone.widget:
+        return zone.widget.render()
 
     return ''

--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -1,3 +1,4 @@
+
 from django import template
 
 from dispatch.theme import ThemeManager
@@ -13,9 +14,8 @@ def zone(zone_id):
     except ZoneNotFound:
         return ''
 
-    try:
-        return zone.widget.render()
-    except:
-        pass        
+    widget = zone.widget
+    if widget is not None:
+        return widget.render()
 
     return ''

--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -11,11 +11,11 @@ def zone(zone_id):
     try:
         zone = ThemeManager.Zones.get(zone_id)
     except ZoneNotFound:
-        return None
+        return ''
 
-    widget = zone.widget
-
-    if widget is not None:
+    try:
         return zone.widget.render()
+    except:
+        pass        
 
     return ''

--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -1,7 +1,7 @@
 from django import template
 
 from dispatch.theme import ThemeManager
-from dispatch.theme.exceptions import ZoneNotFound
+from dispatch.theme.exceptions import ZoneNotFound, WidgetNotFound
 
 register = template.Library()
 
@@ -13,7 +13,9 @@ def zone(zone_id):
     except ZoneNotFound:
         return ''
 
-    if zone.widget:
+    try:
         return zone.widget.render()
+    except WidgetNotFound:
+        pass
 
     return ''

--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -13,4 +13,9 @@ def zone(zone_id):
     except ZoneNotFound:
         return None
 
-    return zone.widget.render()
+    widget = zone.widget
+
+    if widget is not None:
+        return zone.widget.render()
+
+    return ''

--- a/dispatch/apps/frontend/themes/default/templates/widgets/test-invalid-zone.html
+++ b/dispatch/apps/frontend/themes/default/templates/widgets/test-invalid-zone.html
@@ -1,0 +1,5 @@
+{% load widgets %}
+
+<div class="zone">
+{% zone 'invalid-zone' %}
+</div>

--- a/dispatch/static/manager/src/js/actions/ZonesActions.js
+++ b/dispatch/static/manager/src/js/actions/ZonesActions.js
@@ -3,7 +3,13 @@ import { normalize, arrayOf } from 'normalizr'
 
 import DispatchAPI from '../api/dispatch'
 import * as types from '../constants/ActionTypes'
-import { zoneSchema, widgetSchema, articleSchema, imageSchema } from '../constants/Schemas'
+import {
+  zoneSchema,
+  widgetSchema,
+  articleSchema,
+  imageSchema,
+  eventSchema
+} from '../constants/Schemas'
 
 function normalizeZoneData(field, data) {
   switch (field.type) {
@@ -11,6 +17,8 @@ function normalizeZoneData(field, data) {
     return field.many ? normalize(data, arrayOf(articleSchema)) : normalize(data, articleSchema)
   case 'image':
     return field.many ? normalize(data, arrayOf(imageSchema)) : normalize(data, imageSchema)
+  case 'event':
+    return field.many ? normalize(data, arrayOf(eventSchema)) : normalize(data, eventSchema)
   default:
     return {
       result: data,
@@ -20,13 +28,11 @@ function normalizeZoneData(field, data) {
 }
 
 function normalizeZone(zone) {
-
   const fields = R.path(['widget', 'fields'], zone) || []
 
   let fieldEntities = {}
 
   fields.forEach(field => {
-
     if (!zone.data[field.name]) {
       return
     }
@@ -54,7 +60,6 @@ function normalizeZone(zone) {
 }
 
 function normalizeZones(zones) {
-
   let results = []
   let entities = {}
 

--- a/dispatch/static/manager/src/js/components/ZoneEditor/WidgetField.js
+++ b/dispatch/static/manager/src/js/components/ZoneEditor/WidgetField.js
@@ -5,7 +5,6 @@ import * as fields from '../fields'
 import { FormInput } from '../inputs'
 
 export default function WidgetField(props) {
-
   const Field = fields[props.field.type]
 
   return (

--- a/dispatch/static/manager/src/js/components/ZoneEditor/index.js
+++ b/dispatch/static/manager/src/js/components/ZoneEditor/index.js
@@ -35,14 +35,13 @@ class ZoneEditorComponent extends React.Component {
   }
 
   render() {
-
     if (!this.props.zone) {
       return (<div>Loading</div>)
     }
 
     const fields = this.props.widget ? this.props.widget.fields.map((field) => (
       <WidgetField
-        key={field.name}
+        key={`widget-field__${this.props.widget.id}__${field.name}`}
         field={field}
         data={this.props.zone.data[field.name] || null}
         onChange={(data) => this.updateField(field.name, data)} />

--- a/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
@@ -18,13 +18,15 @@ class EventSelectInputComponent extends React.Component {
   }
 
   render() {
-
     const label = this.props.many ? 'events' : 'event'
+
+    const selected = this.props.many ? this.props.selected.map(item => item.id || item) :
+      (this.props.selected ? this.props.selected.id : null)
 
     return (
       <ItemSelectInput
         many={this.props.many}
-        selected={this.props.selected ? this.props.selected.id : null}
+        selected={selected}
         results={this.props.events.ids}
         entities={this.props.entities.events}
         onChange={(selected) => this.props.onChange(selected)}

--- a/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
@@ -33,7 +33,10 @@ class EventSelectInputComponent extends React.Component {
   }
 
   getSelected() {
-    return this.props.many ? this.props.selected.map(item => item.id || item) : this.props.selected.id || this.props.selected
+    if (this.props.selected) {
+      return this.props.many ? this.props.selected.map(item => item.id || item) : this.props.selected.id || this.props.selected
+    }
+    return null
   }
 
   render() {

--- a/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
@@ -21,7 +21,7 @@ class EventSelectInputComponent extends React.Component {
     const label = this.props.many ? 'events' : 'event'
 
     const selected = this.props.many ? this.props.selected.map(item => item.id || item) :
-      (this.props.selected ? this.props.selected.id : null)
+      (this.props.selected ? this.props.selected.id || this.props.selected : null)
 
     return (
       <ItemSelectInput

--- a/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import R from 'ramda'
 import { connect } from 'react-redux'
 
 import ItemSelectInput from './ItemSelectInput'
@@ -18,34 +17,13 @@ class EventSelectInputComponent extends React.Component {
     this.props.listEvents(this.props.token, queryObj)
   }
 
-  componentDidMount() {
-    this.props.onChange(this.getSelected())
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.selected != this.props.selected) {
-      const selected = this.getSelected()
-      if ((this.props.many && this.props.selected.length && R.difference(selected, this.props.selected).length)
-        || (!this.props.many && selected != this.props.selected)) {
-        this.props.onChange(selected)
-      }
-    }
-  }
-
-  getSelected() {
-    if (this.props.selected) {
-      return this.props.many ? this.props.selected.map(item => item.id || item) : this.props.selected.id || this.props.selected
-    }
-    return null
-  }
-
   render() {
     const label = this.props.many ? 'events' : 'event'
 
     return (
       <ItemSelectInput
         many={this.props.many}
-        selected={this.getSelected()}
+        selected={this.props.selected}
         results={this.props.events.ids}
         entities={this.props.entities.events}
         onChange={(selected) => this.props.onChange(selected)}

--- a/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import R from 'ramda'
 import { connect } from 'react-redux'
 
 import ItemSelectInput from './ItemSelectInput'
@@ -17,16 +18,31 @@ class EventSelectInputComponent extends React.Component {
     this.props.listEvents(this.props.token, queryObj)
   }
 
+  componentDidMount() {
+    this.props.onChange(this.getSelected())
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.selected != this.props.selected) {
+      const selected = this.getSelected()
+      if ((this.props.many && this.props.selected.length && R.difference(selected, this.props.selected).length)
+        || (!this.props.many && selected != this.props.selected)) {
+        this.props.onChange(selected)
+      }
+    }
+  }
+
+  getSelected() {
+    return this.props.many ? this.props.selected.map(item => item.id || item) : this.props.selected.id || this.props.selected
+  }
+
   render() {
     const label = this.props.many ? 'events' : 'event'
-
-    const selected = this.props.many ? this.props.selected.map(item => item.id || item) :
-      (this.props.selected ? this.props.selected.id || this.props.selected : null)
 
     return (
       <ItemSelectInput
         many={this.props.many}
-        selected={selected}
+        selected={this.getSelected()}
         results={this.props.events.ids}
         entities={this.props.entities.events}
         onChange={(selected) => this.props.onChange(selected)}

--- a/dispatch/tests/test_widget_render.py
+++ b/dispatch/tests/test_widget_render.py
@@ -215,3 +215,35 @@ class WidgetRenderTestCase(DispatchAPITestCase, DispatchMediaTestMixin):
 
         self.assertEqual(data, widget.prepare_data())
         self.assertEqual(result, html)
+
+    def test_empty_zone_render(self):
+        """Zone without widget attached should render empty"""
+
+        register.zone(TestZone)
+
+        zone = TestZone()
+
+        validated_data = {
+            'widget': None,
+            'data': {}
+        }
+
+        zone.save(validated_data)
+
+        template = loader.get_template('widgets/zones.html')
+
+        result = template.render()
+
+        html = u'\n\n<div class="zone">\n\n</div>\n'
+
+        self.assertEqual(result,  html)
+
+    def test_invalid_zone(self):
+
+        template = loader.get_template('widgets/test-invalid-zone.html')
+
+        result = template.render()
+
+        html = u'\n\n<div class="zone">\n\n</div>\n'
+
+        self.assertEqual(result, html)


### PR DESCRIPTION
currently if zone has no widget attached to it, it throws an error. This makes it easy to break the site from the dispatch admin panel. 

this check just prevents a nonetype error and an empty string in that case, so the view can still render.

Also returning `None` causes the text None to actually be rendered. So I replaced the return with an empty string in the other try block.