### PR TITLE
Fix broken EventSelectInput

### DIFF
--- a/dispatch/static/manager/src/js/actions/ZonesActions.js
+++ b/dispatch/static/manager/src/js/actions/ZonesActions.js
@@ -3,7 +3,13 @@ import { normalize, arrayOf } from 'normalizr'
 
 import DispatchAPI from '../api/dispatch'
 import * as types from '../constants/ActionTypes'
-import { zoneSchema, widgetSchema, articleSchema, imageSchema } from '../constants/Schemas'
+import {
+  zoneSchema,
+  widgetSchema,
+  articleSchema,
+  imageSchema,
+  eventSchema
+} from '../constants/Schemas'
 
 function normalizeZoneData(field, data) {
   switch (field.type) {
@@ -11,6 +17,8 @@ function normalizeZoneData(field, data) {
     return field.many ? normalize(data, arrayOf(articleSchema)) : normalize(data, articleSchema)
   case 'image':
     return field.many ? normalize(data, arrayOf(imageSchema)) : normalize(data, imageSchema)
+  case 'event':
+    return field.many ? normalize(data, arrayOf(eventSchema)) : normalize(data, eventSchema)
   default:
     return {
       result: data,
@@ -20,13 +28,11 @@ function normalizeZoneData(field, data) {
 }
 
 function normalizeZone(zone) {
-
   const fields = R.path(['widget', 'fields'], zone) || []
 
   let fieldEntities = {}
 
   fields.forEach(field => {
-
     if (!zone.data[field.name]) {
       return
     }
@@ -54,7 +60,6 @@ function normalizeZone(zone) {
 }
 
 function normalizeZones(zones) {
-
   let results = []
   let entities = {}
 

--- a/dispatch/static/manager/src/js/components/ZoneEditor/WidgetField.js
+++ b/dispatch/static/manager/src/js/components/ZoneEditor/WidgetField.js
@@ -5,7 +5,6 @@ import * as fields from '../fields'
 import { FormInput } from '../inputs'
 
 export default function WidgetField(props) {
-
   const Field = fields[props.field.type]
 
   return (

--- a/dispatch/static/manager/src/js/components/ZoneEditor/index.js
+++ b/dispatch/static/manager/src/js/components/ZoneEditor/index.js
@@ -35,14 +35,13 @@ class ZoneEditorComponent extends React.Component {
   }
 
   render() {
-
     if (!this.props.zone) {
       return (<div>Loading</div>)
     }
 
     const fields = this.props.widget ? this.props.widget.fields.map((field) => (
       <WidgetField
-        key={field.name}
+        key={`widget-field__${this.props.widget.id}__${field.name}`}
         field={field}
         data={this.props.zone.data[field.name] || null}
         onChange={(data) => this.updateField(field.name, data)} />

--- a/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/EventSelectInput.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import R from 'ramda'
 import { connect } from 'react-redux'
 
 import ItemSelectInput from './ItemSelectInput'
@@ -18,34 +17,13 @@ class EventSelectInputComponent extends React.Component {
     this.props.listEvents(this.props.token, queryObj)
   }
 
-  componentDidMount() {
-    this.props.onChange(this.getSelected())
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.selected != this.props.selected) {
-      const selected = this.getSelected()
-      if ((this.props.many && this.props.selected.length && R.difference(selected, this.props.selected).length)
-        || (!this.props.many && selected != this.props.selected)) {
-        this.props.onChange(selected)
-      }
-    }
-  }
-
-  getSelected() {
-    if (this.props.selected) {
-      return this.props.many ? this.props.selected.map(item => item.id || item) : this.props.selected.id || this.props.selected
-    }
-    return null
-  }
-
   render() {
     const label = this.props.many ? 'events' : 'event'
 
     return (
       <ItemSelectInput
         many={this.props.many}
-        selected={this.getSelected()}
+        selected={this.props.selected}
         results={this.props.events.ids}
         entities={this.props.entities.events}
         onChange={(selected) => this.props.onChange(selected)}


### PR DESCRIPTION
This is _hopefully_ a more robust fix to the broken `EventSelectInput`. This is my bad -- I should have better communicated how widget field normalization works in order to prevent this.