### PR TITLE
Selectively escape some html elements

### DIFF
--- a/dispatch/static/manager/package.json
+++ b/dispatch/static/manager/package.json
@@ -19,7 +19,6 @@
     "css-loader": "^0.26.1",
     "draft-js": "^0.10.0",
     "es6-promise": "^3.2.1",
-    "escape-html": "^1.0.3",
     "eslint": "^3.17.1",
     "eslint-loader": "^1.6.3",
     "eslint-plugin-react": "^6.10.0",

--- a/dispatch/static/manager/src/js/vendor/dispatch-editor/helpers/convertJSON.js
+++ b/dispatch/static/manager/src/js/vendor/dispatch-editor/helpers/convertJSON.js
@@ -96,7 +96,7 @@ function escapeHTML(block) {
     let data = block.data
 
     data = data.replace('&', '&amp')
-    data = data.replace(/<(?![ab]|em|h[1-6]|lu|ul|\/[ab]|\/em|\/h[1-6]|\/lu|\/ul)/g, '&lt;')
+    data = data.replace(/<(?![ab]|em|h[1-6]|li|ul|\/[ab]|\/em|\/h[1-6]|\/li|\/ul)/g, '&lt;')
 
     block.data = data
   }

--- a/dispatch/static/manager/src/js/vendor/dispatch-editor/helpers/convertJSON.js
+++ b/dispatch/static/manager/src/js/vendor/dispatch-editor/helpers/convertJSON.js
@@ -95,7 +95,7 @@ function escapeHTML(block) {
   if (block.type == 'paragraph') {
     let data = block.data
 
-    data = data.replace('&', '&amp')
+    data = data.replace('&', '&amp;')
     data = data.replace(/<(?![ab]|em|h[1-6]|li|ul|\/[ab]|\/em|\/h[1-6]|\/li|\/ul)/g, '&lt;')
 
     block.data = data

--- a/dispatch/static/manager/src/js/vendor/dispatch-editor/helpers/convertJSON.js
+++ b/dispatch/static/manager/src/js/vendor/dispatch-editor/helpers/convertJSON.js
@@ -7,7 +7,6 @@ import {
   genKey,
   convertFromHTML
 } from 'draft-js'
-import escape from 'escape-html'
 import { List, OrderedMap } from 'immutable'
 
 import convertToHTML from './convertToHTML'
@@ -94,7 +93,12 @@ function fromJSON(jsonBlocks) {
 
 function escapeHTML(block) {
   if (block.type == 'paragraph') {
-    block.data = escape(block.data)
+    let data = block.data
+
+    data = data.replace('&', '&amp')
+    data = data.replace(/<(?![ab]|em|h[1-6]|lu|ul|\/[ab]|\/em|\/h[1-6]|\/lu|\/ul)/g, '&lt;')
+
+    block.data = data
   }
   return block
 }

--- a/dispatch/static/manager/yarn.lock
+++ b/dispatch/static/manager/yarn.lock
@@ -1532,10 +1532,6 @@ es6-weak-map@^2.0.1:
     es6-iterator "^2.0.1"
     es6-symbol "^3.1.1"
 
-escape-html@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
-
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
Addresses #639

Since italic, bold, links, headers, etc used actual html, they need it to be unescaped.
Therefore blanket escaping all the html broke the editor.

It would be simple enough to revert that PR and restore the editor's functionality, but I think it is still worth while to try to escape "stray" html entities.

This PR escapes just two entities: `&` and `<`. But `<` is only escaped when it isn't followed by a valid html tag such as `a`, `em`, etc. This is done using a negative lookahead regex.

By escaping the `<`, a floating `>` becomes a non issue.

Now if a user inserts `<random text between angle brackets>`, it doesn't vanish, as the `<` is escaped, and the `>` alone doesn't indicate a tag, so it's a non issue.

Excuse my verbosity, I wanted to read it back myself to make sure it was sane.