### PR TITLE
Redirect user to login screen if their token can not be verified

### DIFF
--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -458,8 +458,8 @@ class TokenViewSet(viewsets.ModelViewSet):
     def retrieve(self, request, pk):
 
         token_provided = pk
-        get_object_or_404(Token, key=token_provided, user=request.user)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        get_object_or_404(Token, key=token_provided)
+        return Response({'token-valid': True})
 
     def delete(self, request):
         token = get_object_or_404(Token, user=request.user)

--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -459,7 +459,7 @@ class TokenViewSet(viewsets.ModelViewSet):
         try:
             token = Token.objects.get(key=pk)
         except Token.DoesNotExist:
-            return Response({'token_valid': False}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({'token_valid': False}, status=status.HTTP_404_NOT_FOUND)
 
         return Response({'token_valid': True})
 

--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -456,8 +456,11 @@ class TokenViewSet(viewsets.ModelViewSet):
             raise BadCredentials()
 
     def retrieve(self, request, pk):
+        try:
+            token = Token.objects.get(key=pk)
+        except Token.DoesNotExist:
+            return Response({'token_valid': False}, status=status.HTTP_400_BAD_REQUEST)
 
-        get_object_or_404(Token, key=pk)
         return Response({'token_valid': True})
 
     def delete(self, request):
@@ -466,3 +469,6 @@ class TokenViewSet(viewsets.ModelViewSet):
         token.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def get_queryset(self):
+        return None

--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -455,6 +455,12 @@ class TokenViewSet(viewsets.ModelViewSet):
         else:
             raise BadCredentials()
 
+    def retrieve(self, request, pk):
+
+        token_provided = pk
+        get_object_or_404(Token, key=token_provided, user=request.user)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
     def delete(self, request):
         token = get_object_or_404(Token, user=request.user)
 

--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -457,9 +457,8 @@ class TokenViewSet(viewsets.ModelViewSet):
 
     def retrieve(self, request, pk):
 
-        token_provided = pk
-        get_object_or_404(Token, key=token_provided)
-        return Response({'token-valid': True})
+        get_object_or_404(Token, key=pk)
+        return Response({'token_valid': True})
 
     def delete(self, request):
         token = get_object_or_404(Token, user=request.user)

--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -432,9 +432,7 @@ class EventViewSet(DispatchModelViewSet):
 
 
 @permission_classes((AllowAny,))
-class TokenViewSet(viewsets.ModelViewSet):
-
-    model = Token
+class TokenViewSet(viewsets.ViewSet):
 
     def create(self, request):
 
@@ -469,6 +467,3 @@ class TokenViewSet(viewsets.ModelViewSet):
         token.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
-
-    def get_queryset(self):
-        return None

--- a/dispatch/static/manager/src/js/actions/UserActions.js
+++ b/dispatch/static/manager/src/js/actions/UserActions.js
@@ -35,6 +35,23 @@ export function authenticateUser(email, password, nextPath = '/') {
   }
 }
 
+export function verifyToken(token) {
+  return (dispatch) => {
+    dispatch({ type: pending(types.AUTH.VERIFY_TOKEN )})
+
+    return DispatchAPI.auth.verifyToken(token)
+      .then(() => {
+        dispatch({
+          type: fulfilled(types.AUTH.VERIFY_TOKEN)
+        })
+      })
+      .catch(() => {
+        dispatch({
+          type: rejected(types.AUTH.VERIFY_TOKEN)
+        })
+      })
+  }
+}
 
 export function logoutUser(token) {
   return (dispatch) => {

--- a/dispatch/static/manager/src/js/actions/UserActions.js
+++ b/dispatch/static/manager/src/js/actions/UserActions.js
@@ -40,14 +40,16 @@ export function verifyToken(token) {
     dispatch({ type: pending(types.AUTH.VERIFY_TOKEN )})
 
     return DispatchAPI.auth.verifyToken(token)
-      .then(() => {
+      .then((response) => {
         dispatch({
-          type: fulfilled(types.AUTH.VERIFY_TOKEN)
+          type: fulfilled(types.AUTH.VERIFY_TOKEN),
+          response
         })
       })
-      .catch(() => {
+      .catch((response) => {
         dispatch({
-          type: rejected(types.AUTH.VERIFY_TOKEN)
+          type: rejected(types.AUTH.VERIFY_TOKEN),
+          response
         })
       })
   }

--- a/dispatch/static/manager/src/js/actions/UserActions.js
+++ b/dispatch/static/manager/src/js/actions/UserActions.js
@@ -51,6 +51,7 @@ export function verifyToken(token) {
           type: rejected(types.AUTH.VERIFY_TOKEN),
           response
         })
+        dispatch(requireLogin('/'))
       })
   }
 }

--- a/dispatch/static/manager/src/js/api/dispatch.js
+++ b/dispatch/static/manager/src/js/api/dispatch.js
@@ -145,6 +145,9 @@ const DispatchAPI = {
 
       return postRequest('token', null, payload)
     },
+    verifyToken: (token) => {
+      return getRequest('token', token, null)
+    },
     logout: (token) => {
       return deleteRequest('token', null, null, token)
     }

--- a/dispatch/static/manager/src/js/constants/ActionTypes.js
+++ b/dispatch/static/manager/src/js/constants/ActionTypes.js
@@ -17,7 +17,8 @@ export const EVENTS = resourceActionTypes('EVENTS', ['COUNT_PENDING'])
 export const AUTH = actionTypes('AUTH', [
   'LOGIN_REQUIRED',
   'CREATE_TOKEN',
-  'DELETE_TOKEN'
+  'DELETE_TOKEN',
+  'VERIFY_TOKEN'
 ])
 
 // Integration actions

--- a/dispatch/static/manager/src/js/containers/AppContainer.js
+++ b/dispatch/static/manager/src/js/containers/AppContainer.js
@@ -9,14 +9,6 @@ class App extends React.Component {
     this.checkAuthenticated()
   }
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.validToken != this.props.validToken) {
-      if (this.props.validToken === false) {
-        this.props.onRequireLogin('/')
-      }
-    }
-  }
-
   checkAuthenticated() {
     this.props.verifyToken(this.props.token)
   }
@@ -28,16 +20,12 @@ class App extends React.Component {
 
 const mapStateToProps = (state) => {
   return {
-    token: state.app.auth.token,
-    validToken: state.app.auth.validToken
+    token: state.app.auth.token
   }
 }
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    onRequireLogin: (nextPath) => {
-      dispatch(userActions.requireLogin(nextPath))
-    },
     verifyToken: (token) => {
       dispatch(userActions.verifyToken(token))
     }

--- a/dispatch/static/manager/src/js/containers/AppContainer.js
+++ b/dispatch/static/manager/src/js/containers/AppContainer.js
@@ -6,13 +6,19 @@ import * as userActions from '../actions/UserActions'
 class App extends React.Component {
 
   componentWillMount() {
-    if (!this.isAuthenticated()) {
-      this.props.onRequireLogin('/')
+    this.checkAuthenticated()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.validToken != this.props.validToken) {
+      if (this.props.validToken === false) {
+        this.props.onRequireLogin('/')
+      }
     }
   }
 
-  isAuthenticated() {
-    return !!this.props.auth.token
+  checkAuthenticated() {
+    this.props.verifyToken(this.props.token)
   }
 
   render() {
@@ -21,13 +27,19 @@ class App extends React.Component {
 }
 
 const mapStateToProps = (state) => {
-  return state.app
+  return {
+    token: state.app.auth.token,
+    validToken: state.app.auth.validToken
+  }
 }
 
 const mapDispatchToProps = (dispatch) => {
   return {
     onRequireLogin: (nextPath) => {
       dispatch(userActions.requireLogin(nextPath))
+    },
+    verifyToken: (token) => {
+      dispatch(userActions.verifyToken(token))
     }
   }
 }

--- a/dispatch/static/manager/src/js/reducers/AuthReducer.js
+++ b/dispatch/static/manager/src/js/reducers/AuthReducer.js
@@ -43,10 +43,8 @@ reducer.handle(fulfilled(types.AUTH.VERIFY_TOKEN), (state) => {
   return R.merge(state, { validToken: true })
 })
 
-reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state) => {    
-  return R.merge(state, {
-    validToken: false
-  })
+reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state) => {
+  return R.merge(state, { validToken: false })
 })
 
 export default reducer.getReducer()

--- a/dispatch/static/manager/src/js/reducers/AuthReducer.js
+++ b/dispatch/static/manager/src/js/reducers/AuthReducer.js
@@ -8,8 +8,7 @@ import { Reducer, fulfilled, rejected } from '../util/redux'
 const initialState = {
   token: Cookies.get('token'), // Get token stored in browser cookie
   email: Cookies.get('email'), // Get email stored in browser cookie
-  nextPath: null,
-  validToken: null
+  nextPath: null
 }
 
 let reducer = new Reducer(initialState)
@@ -39,10 +38,6 @@ reducer.handle(fulfilled(types.AUTH.DELETE_TOKEN), () => {
   return initialState
 })
 
-reducer.handle(fulfilled(types.AUTH.VERIFY_TOKEN), (state) => {
-  return R.merge(state, { validToken: true })
-})
-
 reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state, action) => {
   const validToken = R.path(['response', 'valid_token'], action)
 
@@ -53,7 +48,7 @@ reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state, action) => {
     return initialState
   }
 
-  return R.merge(state, { validToken: false })
+  return state
 })
 
 export default reducer.getReducer()

--- a/dispatch/static/manager/src/js/reducers/AuthReducer.js
+++ b/dispatch/static/manager/src/js/reducers/AuthReducer.js
@@ -43,7 +43,16 @@ reducer.handle(fulfilled(types.AUTH.VERIFY_TOKEN), (state) => {
   return R.merge(state, { validToken: true })
 })
 
-reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state) => {
+reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state, action) => {
+  const validToken = R.path(['response', 'valid_token'], action)
+
+  if (validToken === false) {
+    Cookies.remove('token')
+    Cookies.remove('email')
+
+    return initialState
+  }
+
   return R.merge(state, { validToken: false })
 })
 

--- a/dispatch/static/manager/src/js/reducers/AuthReducer.js
+++ b/dispatch/static/manager/src/js/reducers/AuthReducer.js
@@ -3,12 +3,13 @@ import Cookies from 'js-cookie'
 
 import * as types from '../constants/ActionTypes'
 
-import { Reducer, fulfilled } from '../util/redux'
+import { Reducer, fulfilled, rejected } from '../util/redux'
 
 const initialState = {
   token: Cookies.get('token'), // Get token stored in browser cookie
   email: Cookies.get('email'), // Get email stored in browser cookie
-  nextPath: null
+  nextPath: null,
+  validToken: null
 }
 
 let reducer = new Reducer(initialState)
@@ -36,6 +37,21 @@ reducer.handle(fulfilled(types.AUTH.DELETE_TOKEN), () => {
   Cookies.remove('email')
 
   return initialState
+})
+
+reducer.handle(fulfilled(types.AUTH.VERIFY_TOKEN), (state) => {
+  return R.merge(state, { validToken: true })
+})
+
+reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state) => {
+  Cookies.remove('token')
+  Cookies.remove('email')
+
+  return R.merge(state, {
+    token: null,
+    email: null,
+    validToken: false
+  })
 })
 
 export default reducer.getReducer()

--- a/dispatch/static/manager/src/js/reducers/AuthReducer.js
+++ b/dispatch/static/manager/src/js/reducers/AuthReducer.js
@@ -43,13 +43,8 @@ reducer.handle(fulfilled(types.AUTH.VERIFY_TOKEN), (state) => {
   return R.merge(state, { validToken: true })
 })
 
-reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state) => {
-  Cookies.remove('token')
-  Cookies.remove('email')
-
+reducer.handle(rejected(types.AUTH.VERIFY_TOKEN), (state) => {    
   return R.merge(state, {
-    token: null,
-    email: null,
     validToken: false
   })
 })

--- a/dispatch/tests/test_api_auth.py
+++ b/dispatch/tests/test_api_auth.py
@@ -135,4 +135,5 @@ class AuthenticationTests(DispatchAPITestCase):
         url = reverse('api-token-detail', args=[invalid_token])
 
         response = self.client.get(url, None, format='json')
+        self.assertEqual(response.data['token_valid'], False)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/dispatch/tests/test_api_auth.py
+++ b/dispatch/tests/test_api_auth.py
@@ -106,3 +106,33 @@ class AuthenticationTests(DispatchAPITestCase):
 
         response = self.client.delete(url, {}, format='json')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_verify_token(self):
+        """
+        Test that token verification works
+        """
+
+        url = reverse('api-token-list')
+        data = {
+            'email': 'test@test.com',
+            'password': 'testing123'
+        }
+        response = self.client.post(url, data, format='json')
+
+        url = reverse('api-token-detail', args=[response.data['token']])
+
+        response = self.client.get(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['token-valid'], True)
+
+        def test_verify_token_invalid_token(self):
+            """
+            Test that token verification rejects an invalid token
+            """
+
+            invalid_token = 'thisisnotavalidtoken'
+
+            url = reverse('api-token-detail', args=[invalid_token])
+
+            response = self.client.get(url, None, format='json')
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/dispatch/tests/test_api_auth.py
+++ b/dispatch/tests/test_api_auth.py
@@ -123,7 +123,7 @@ class AuthenticationTests(DispatchAPITestCase):
 
         response = self.client.get(url, None, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['token-valid'], True)
+        self.assertEqual(response.data['token_valid'], True)
 
     def test_verify_token_invalid_token(self):
         """

--- a/dispatch/tests/test_api_auth.py
+++ b/dispatch/tests/test_api_auth.py
@@ -125,14 +125,14 @@ class AuthenticationTests(DispatchAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['token-valid'], True)
 
-        def test_verify_token_invalid_token(self):
-            """
-            Test that token verification rejects an invalid token
-            """
+    def test_verify_token_invalid_token(self):
+        """
+        Test that token verification rejects an invalid token
+        """
 
-            invalid_token = 'thisisnotavalidtoken'
+        invalid_token = 'thisisnotavalidtoken'
 
-            url = reverse('api-token-detail', args=[invalid_token])
+        url = reverse('api-token-detail', args=[invalid_token])
 
-            response = self.client.get(url, None, format='json')
-            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        response = self.client.get(url, None, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
1. Add a token verification endpoint
2. check it when the app loads, if the user's token is invalid, redirect them to the login page. The token is not deleted from cookies, in case the request failed for other reasons, ie. internet failure. This way the user can just reload the page. 