### PR TITLE
add more columns to the event index page

### DIFF
--- a/dispatch/static/manager/src/js/pages/Events/EventIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Events/EventIndexPage.js
@@ -64,7 +64,7 @@ function EventsPageComponent(props) {
       pageTitle='Events'
       headers={[ 'Title', 'Published', 'Time', 'Location', 'Type']}
       extraColumns={[
-        event => event.is_published ? 'Published' : 'Unpublished',
+        event => event.is_published ? 'Published' : 'Not Published',
         event => `${humanizeDatetime(event.start_time)} - ${humanizeDatetime(event.end_time)}`,
         event => event.location,
         event => event.category

--- a/dispatch/static/manager/src/js/pages/Events/EventIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Events/EventIndexPage.js
@@ -5,6 +5,7 @@ import { replace } from 'react-router-redux'
 import EventPendingTag from '../../components/EventEditor/EventPendingTag'
 import ItemIndexPage from '../ItemIndexPage'
 import eventsActions from '../../actions/EventsActions'
+import { humanizeDatetime } from  '../../util/helpers'
 
 const mapStateToProps = (state) => {
   return {
@@ -61,6 +62,13 @@ function EventsPageComponent(props) {
       typePlural='events'
       displayColumn='title'
       pageTitle='Events'
+      headers={[ 'Title', 'Published', 'Time', 'Location', 'Type']}
+      extraColumns={[
+        event => event.is_published ? 'Published' : 'Unpublished',
+        event => `${humanizeDatetime(event.start_time)} - ${humanizeDatetime(event.end_time)}`,
+        event => event.location,
+        event => event.category
+      ]}
       toolbarContent={<EventPendingTag />}
       {... props} />
   )


### PR DESCRIPTION
I think events got missed when I made the columns extendable since they were in a different branch at the time.

Anyway, pretty straightforward. 

Are there any particular columns that make more or less sense to display?