### PR TITLE
Widget templatetag keyword arguments

### DIFF
--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -14,7 +14,7 @@ def zone(zone_id, **kwargs):
         return ''
 
     try:
-        return zone.widget.render(extra_ctx_kw=kwargs)
+        return zone.widget.render(add_context=kwargs)
     except (WidgetNotFound, AttributeError):
         pass
 

--- a/dispatch/apps/frontend/templatetags/widgets.py
+++ b/dispatch/apps/frontend/templatetags/widgets.py
@@ -6,7 +6,7 @@ from dispatch.theme.exceptions import ZoneNotFound, WidgetNotFound
 register = template.Library()
 
 @register.simple_tag
-def zone(zone_id):
+def zone(zone_id, **kwargs):
 
     try:
         zone = ThemeManager.Zones.get(zone_id)
@@ -14,7 +14,7 @@ def zone(zone_id):
         return ''
 
     try:
-        return zone.widget.render()
+        return zone.widget.render(extra_ctx_kw=kwargs)
     except (WidgetNotFound, AttributeError):
         pass
 

--- a/dispatch/apps/frontend/themes/default/templates/widgets/test-widget-kwargs.html
+++ b/dispatch/apps/frontend/themes/default/templates/widgets/test-widget-kwargs.html
@@ -1,0 +1,5 @@
+{% load widgets %}
+
+<div class="zone">
+{% zone 'test-zone' extra=extra data=data %}
+</div>

--- a/dispatch/apps/frontend/themes/default/templates/widgets/test-widget.html
+++ b/dispatch/apps/frontend/themes/default/templates/widgets/test-widget.html
@@ -5,5 +5,5 @@
     {% if image %}<img class="image" src="{{ image.get_absolute_url }}"/>{% endif %}
     {% if events %}{% for event in events %}
       <div class="events">{{ event.title|safe }}</div>
-    {% endfor %}{% endif %}
+    {% endfor %}{% endif %}{{ extra }}
 </div>

--- a/dispatch/tests/test_widget_render.py
+++ b/dispatch/tests/test_widget_render.py
@@ -19,7 +19,7 @@ class TestWidget(Widget):
     name = 'Test widget'
     template = 'widgets/test-widget.html'
 
-    valid_extra_ctx_kw = ('extra',)
+    accepted_keywords = ('extra',)
 
     zones = [TestZone]
 

--- a/dispatch/tests/test_widget_render.py
+++ b/dispatch/tests/test_widget_render.py
@@ -1,4 +1,5 @@
 from django.template import loader
+from django.utils.html import mark_safe
 
 from dispatch.theme import register
 from dispatch.theme.widgets import Zone, Widget
@@ -17,6 +18,8 @@ class TestWidget(Widget):
     id = 'test-widget'
     name = 'Test widget'
     template = 'widgets/test-widget.html'
+
+    valid_extra_ctx_kw = ('extra',)
 
     zones = [TestZone]
 
@@ -245,5 +248,63 @@ class WidgetRenderTestCase(DispatchAPITestCase, DispatchMediaTestMixin):
         result = template.render()
 
         html = u'\n\n<div class="zone">\n\n</div>\n'
+
+        self.assertEqual(result, html)
+
+
+    def test_zone_render_kwargs(self):
+        """The test zone should be properly rendered when provided valid kwargs"""
+
+        register.zone(TestZone)
+        register.widget(TestWidget)
+
+        zone = TestZone()
+        widget = TestWidget()
+
+        validated_data = {
+            'widget': 'test-widget',
+            'data': {
+              'title': 'test title 1',
+              'description': 'test description'
+            }
+        }
+
+        zone.save(validated_data)
+
+        template = loader.get_template('widgets/test-widget-kwargs.html')
+
+        result = template.render({ 'extra': mark_safe('<div class="testing">testing</div>') })
+
+        html = u'\n\n<div class="zone">\n<div class="widget">\n    <img class="title">test title 1</div>\n    <div class="description">test description</div>\n    \n    \n    <div class="testing">testing</div>\n</div>\n\n</div>\n'
+
+        self.assertEqual(result, html)
+
+    def test_zone_render_invalid_kwargs(self):
+        """The test zone/widget should ignore kwargs that aren't in the accepted list"""
+
+        register.zone(TestZone)
+        register.widget(TestWidget)
+
+        zone = TestZone()
+        widget = TestWidget()
+
+        validated_data = {
+            'widget': 'test-widget',
+            'data': {
+              'title': 'test title 1',
+              'description': 'test description'
+            }
+        }
+
+        zone.save(validated_data)
+
+        template = loader.get_template('widgets/test-widget-kwargs.html')
+
+        # in this case, data isn't in the list of accepted keywords,
+        # if it was, or the verification failed, then it would be overriden
+        # by the value provided in this context
+        result = template.render({ 'data': { 'title': 'some invalid data' }})
+
+        html = u'\n\n<div class="zone">\n<div class="widget">\n    <img class="title">test title 1</div>\n    <div class="description">test description</div>\n    \n    \n    \n</div>\n\n</div>\n'
 
         self.assertEqual(result, html)

--- a/dispatch/theme/widgets.py
+++ b/dispatch/theme/widgets.py
@@ -102,7 +102,7 @@ class Widget(object):
 
     __metaclass__ = MetaWidget
 
-    valid_extra_ctx_kw = ()
+    accepted_keywords = ()
     """Accepted extra keyword arguments when rendered via template tag.
     Added to context for render if provided to templatetag.
     """
@@ -144,7 +144,7 @@ class Widget(object):
 
         return result
 
-    def render(self, data=None, extra_ctx_kw=None):
+    def render(self, data=None, add_context=None):
         """Renders the widget as HTML"""
 
         template = loader.get_template(self.template)
@@ -152,9 +152,9 @@ class Widget(object):
         if not data:
             data = self.context(self.prepare_data())
 
-        if extra_ctx_kw is not None:
-            for key, value in extra_ctx_kw.iteritems():
-                if key in self.valid_extra_ctx_kw:
+        if add_context is not None:
+            for key, value in add_context.iteritems():
+                if key in self.accepted_keywords:
                     data[key] = value
 
         return template.render(data)

--- a/dispatch/theme/widgets.py
+++ b/dispatch/theme/widgets.py
@@ -102,6 +102,11 @@ class Widget(object):
 
     __metaclass__ = MetaWidget
 
+    valid_extra_ctx_kw = ()
+    """Accepted extra keyword arguments when rendered via template tag.
+    Added to context for render if provided to templatetag.
+    """
+
     def __init__(self):
         self.data = {}
 
@@ -139,15 +144,20 @@ class Widget(object):
 
         return result
 
-    def render(self, data=None):
+    def render(self, data=None, extra_ctx_kw=None):
         """Renders the widget as HTML"""
 
         template = loader.get_template(self.template)
 
         if not data:
-            return template.render(self.context(self.prepare_data()))
-        else:
-            return template.render(data)
+            data = self.context(self.prepare_data())
+
+        if extra_ctx_kw is not None:
+            for key, value in extra_ctx_kw.iteritems():
+                if key in self.valid_extra_ctx_kw:
+                    data[key] = value
+
+        return template.render(data)
 
     def context(self, data):
         """Optional method to add additional data to the deplate context before rendering"""


### PR DESCRIPTION
The template tag for rendering zones accepts keyword arguments.

These are passed to the widgets render method. If the keywords are in the list of accepted keywords for that widget, that key/value is extended onto the context of the widget before it is rendered.

This data path adds flexibility to the theme, allowing data to handed between the view/widget context, reducing the need for redundant db queries. 