### PR TITLE
Profile page

### DIFF
--- a/dispatch/apps/api/views.py
+++ b/dispatch/apps/api/views.py
@@ -149,6 +149,14 @@ class UserViewSet(DispatchModelViewSet):
 
     permission_classes = (IsAuthenticated,)
 
+    def retrieve(self, request, pk=None):
+        queryset = User.objects.all()
+        if pk == 'me':
+            pk = request.user.id
+        user = get_object_or_404(queryset, pk=pk)
+        serializer = UserSerializer(user)
+        return Response(serializer.data)
+
 class TagViewSet(DispatchModelViewSet):
     """
     Viewset for Tag model views.

--- a/dispatch/static/manager/src/js/actions/UserActions.js
+++ b/dispatch/static/manager/src/js/actions/UserActions.js
@@ -2,6 +2,8 @@ import { replace } from 'react-router-redux'
 
 import * as types from '../constants/ActionTypes'
 import DispatchAPI from '../api/dispatch'
+import { userSchema } from '../constants/Schemas'
+import { ResourceActions } from '../util/redux'
 
 import { pending, fulfilled, rejected } from '../util/redux'
 
@@ -77,3 +79,9 @@ export function logoutUser(token) {
       })
   }
 }
+
+export default new ResourceActions(
+  types.USERS,
+  DispatchAPI.users,
+  userSchema
+)

--- a/dispatch/static/manager/src/js/api/dispatch.js
+++ b/dispatch/static/manager/src/js/api/dispatch.js
@@ -371,6 +371,14 @@ const DispatchAPI = {
     delete: (token, eventId) => {
       return deleteRequest('events', eventId, null, token)
     },
+  },
+  'users': {
+    get: (token, userId) => {
+      return getRequest('users', userId, null, token)
+    },
+    save: (token, userId, data) => {
+      return patchMultipartRequest('users', userId, data, token)
+    }
   }
 }
 

--- a/dispatch/static/manager/src/js/api/dispatch.js
+++ b/dispatch/static/manager/src/js/api/dispatch.js
@@ -377,7 +377,7 @@ const DispatchAPI = {
       return getRequest('users', userId, null, token)
     },
     save: (token, userId, data) => {
-      return patchMultipartRequest('users', userId, data, token)
+      return patchRequest('users', userId, data, token)
     }
   }
 }

--- a/dispatch/static/manager/src/js/components/ItemEditor/index.js
+++ b/dispatch/static/manager/src/js/components/ItemEditor/index.js
@@ -91,7 +91,7 @@ class ItemEditor extends React.Component {
             deleteListItem={() => this.props.deleteListItem(this.props.token, this.props.itemId, this.props.afterDelete)}
             goBack={this.props.goBack}
             extraButton={this.props.extraButton} />
-          <div className='u-container u-container--padded' style={{ overflowY: 'scroll' }}>
+          <div className='u-container u-container--padded u-container--vscroll'>
             <this.props.form
               listItem={listItem}
               errors={this.props.listItem ? this.props.listItem.errors : {}}

--- a/dispatch/static/manager/src/js/components/inputs/FormInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/FormInput.js
@@ -3,7 +3,11 @@ import React from 'react'
 export default function FormInput(props) {
 
   const className = props.padded ? 'c-form-input' : 'c-form-input c-form-input--no-padding'
-  const error = (<span className='c-form-input__error pt-tag pt-intent-danger'>{props.error}</span>)
+  const error = (
+    <span className='c-form-input__error pt-tag pt-intent-danger'>
+      {Array.isArray(props.error) ? props.error.join(' ') : props.error}
+    </span>
+  )
 
   if (props.label) {
     return (

--- a/dispatch/static/manager/src/js/constants/ActionTypes.js
+++ b/dispatch/static/manager/src/js/constants/ActionTypes.js
@@ -12,6 +12,7 @@ export const TAGS = resourceActionTypes('TAGS')
 export const TEMPLATES = resourceActionTypes('TEMPLATES')
 export const GALLERIES = resourceActionTypes('GALLERIES')
 export const EVENTS = resourceActionTypes('EVENTS', ['COUNT_PENDING'])
+export const USERS = resourceActionTypes('USERS')
 
 // Authentication actions
 export const AUTH = actionTypes('AUTH', [

--- a/dispatch/static/manager/src/js/constants/Schemas.js
+++ b/dispatch/static/manager/src/js/constants/Schemas.js
@@ -13,6 +13,7 @@ export const gallerySchema = new Schema('galleries')
 export const zoneSchema = new Schema('zones')
 export const widgetSchema = new Schema('widgets')
 export const eventSchema = new Schema('events')
+export const userSchema = new Schema('users')
 
 articleSchema.define({
   section: sectionSchema,
@@ -38,4 +39,8 @@ imageSchema.define({
 
 zoneSchema.define({
   widget: widgetSchema
+})
+
+userSchema.define({
+  person: personSchema
 })

--- a/dispatch/static/manager/src/js/pages/ProfilePage.js
+++ b/dispatch/static/manager/src/js/pages/ProfilePage.js
@@ -7,6 +7,8 @@ import userActions from '../actions/userActions'
 import PersonEditor from '../components/PersonEditor'
 import { FormInput, TextInput } from '../components/inputs'
 
+require('../../styles/components/user_form.scss')
+
 class ProfilePageComponent extends React.Component {
   loadUser() {
     this.props.getUser(this.props.token, 'me')
@@ -53,11 +55,12 @@ class ProfilePageComponent extends React.Component {
     ) : null
 
     const userForm = userId ? (
-      <div>
+      <div className='u-container u-container--padded c-user-form'>
+        <div className='c-user-form__heading'>Account Details</div>
         <form onSubmit={e => e.preventDefault()}>
           <FormInput
             label='Email'
-            padded={true}
+            padded={false}
             error={errors.email}>
             <TextInput
               placeholder='name@domain.tld'
@@ -67,7 +70,7 @@ class ProfilePageComponent extends React.Component {
           </FormInput>
           <FormInput
             label='Password'
-            padded={true}
+            padded={false}
             error={errors.password_a}>
             <TextInput
               placeholder=''
@@ -78,7 +81,7 @@ class ProfilePageComponent extends React.Component {
           </FormInput>
           <FormInput
             label='Password Again'
-            padded={true}
+            padded={false}
             error={errors.password_b}>
             <TextInput
               placeholder=''

--- a/dispatch/static/manager/src/js/pages/ProfilePage.js
+++ b/dispatch/static/manager/src/js/pages/ProfilePage.js
@@ -3,7 +3,7 @@ import R from 'ramda'
 import { connect } from 'react-redux'
 import { Button, Intent } from '@blueprintjs/core'
 
-import userActions from '../actions/userActions'
+import userActions from '../actions/UserActions'
 import PersonEditor from '../components/PersonEditor'
 import { FormInput, TextInput } from '../components/inputs'
 

--- a/dispatch/static/manager/src/js/pages/ProfilePage.js
+++ b/dispatch/static/manager/src/js/pages/ProfilePage.js
@@ -1,7 +1,64 @@
 import React from 'react'
+import { connect } from 'react-redux'
 
-export default function ProfilePage() {
-  return (
-    <h1>This is the Profile Page</h1>
-  )
+import userActions from '../actions/userActions'
+
+class ProfilePageComponent extends React.Component {
+  componentDidMount() {
+    this.props.getUser(this.props.token, 'me')
+  }
+
+  render() {
+    return (
+      <h1>This is the Profile Page</h1>
+    )
+  }
 }
+
+const processData = (data) => {
+  let formData = new FormData()
+
+  formData.append('title', data.title || '')
+  formData.append('description', data.description || '')
+  formData.append('host', data.host || '')
+  if (data.image instanceof File) {
+    formData.append('image', data.image, data.image.name)
+  }
+  formData.append('location', data.location || '')
+  formData.append('address', data.address || '')
+  formData.append('category', data.category || '')
+  formData.append('facebook_url', data.facebook_url || '')
+  formData.append('submitter_email', data.submitter_email || '')
+  formData.append('submitter_phone', data.submitter_phone || '')
+
+  return formData
+}
+
+const mapStateToProps = (state) => {
+  return {
+    user: state.app.events.single,
+    entities: {
+      remote: state.app.entities.users,
+      local: state.app.entities.local.users,
+    },
+    token: state.app.auth.token
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    getUser: (token, eventId) => {
+      dispatch(userActions.get(token, eventId))
+    },
+    saveUser: (token, eventId, data) => {
+      dispatch(userActions.save(token, eventId, processData(data)))
+    }
+  }
+}
+
+const ProfilePage = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ProfilePageComponent)
+
+export default ProfilePage

--- a/dispatch/static/manager/src/js/pages/ProfilePage.js
+++ b/dispatch/static/manager/src/js/pages/ProfilePage.js
@@ -1,45 +1,116 @@
 import React from 'react'
+import R from 'ramda'
 import { connect } from 'react-redux'
+import { Button, Intent } from '@blueprintjs/core'
 
 import userActions from '../actions/userActions'
+import PersonEditor from '../components/PersonEditor'
+import { FormInput, TextInput } from '../components/inputs'
 
 class ProfilePageComponent extends React.Component {
-  componentDidMount() {
+  loadUser() {
     this.props.getUser(this.props.token, 'me')
   }
 
+  componentDidMount() {
+    this.loadUser()
+  }
+
+  getUserId() {
+    return this.props.user.id
+  }
+
+  getPersonId() {
+    const userId = this.getUserId()
+    return userId ? this.props.entities.remote[userId].person : null
+  }
+
+  getUser() {
+    const userId = this.getUserId()
+    return userId ? (this.props.entities.local ? this.props.entities.local[userId]
+      : this.props.entities.remote[userId]) : null
+  }
+
+  handleUpdate(field, value) {
+    this.props.setUser(R.assoc(field, value, this.getUser()))
+  }
+
+  save() {
+    this.props.saveUser(this.props.token, this.getUserId(), this.getUser())
+  }
+
   render() {
+    const userId = this.getUserId()
+    const personId = this.getPersonId()
+    const user = this.getUser()
+    const errors = this.props.user.errors
+
+    const personEditor = personId ? (
+      <PersonEditor
+        itemId={personId}
+        goBack={this.props.history.goBack}
+        route={this.props.route} />
+    ) : null
+
+    const userForm = userId ? (
+      <div>
+        <form onSubmit={e => e.preventDefault()}>
+          <FormInput
+            label='Email'
+            padded={true}
+            error={errors.email}>
+            <TextInput
+              placeholder='name@domain.tld'
+              value={user.email || ''}
+              fill={true}
+              onChange={ e => this.handleUpdate('email', e.target.value) } />
+          </FormInput>
+          <FormInput
+            label='Password'
+            padded={true}
+            error={errors.password_a}>
+            <TextInput
+              placeholder=''
+              value={user.password_a || ''}
+              fill={true}
+              type='password'
+              onChange={ e => this.handleUpdate('password_a', e.target.value) } />
+          </FormInput>
+          <FormInput
+            label='Password Again'
+            padded={true}
+            error={errors.password_b}>
+            <TextInput
+              placeholder=''
+              value={user.password_b || ''}
+              fill={true}
+              type='password'
+              onChange={ e => this.handleUpdate('password_b', e.target.value) } />
+          </FormInput>
+        </form>
+        <Button
+          intent={Intent.SUCCESS}
+          onClick={() => this.save()}>
+          Save
+        </Button>
+      </div>
+    ) : null
+
     return (
-      <h1>This is the Profile Page</h1>
+      <div>
+        {personEditor}
+        {userForm}
+      </div>
     )
   }
 }
 
-const processData = (data) => {
-  let formData = new FormData()
-
-  formData.append('title', data.title || '')
-  formData.append('description', data.description || '')
-  formData.append('host', data.host || '')
-  if (data.image instanceof File) {
-    formData.append('image', data.image, data.image.name)
-  }
-  formData.append('location', data.location || '')
-  formData.append('address', data.address || '')
-  formData.append('category', data.category || '')
-  formData.append('facebook_url', data.facebook_url || '')
-  formData.append('submitter_email', data.submitter_email || '')
-  formData.append('submitter_phone', data.submitter_phone || '')
-
-  return formData
-}
-
 const mapStateToProps = (state) => {
   return {
-    user: state.app.events.single,
+    user: state.app.users.single,
     entities: {
       remote: state.app.entities.users,
-      local: state.app.entities.local.users,
+      local: state.app.entities.local.users
     },
     token: state.app.auth.token
   }
@@ -51,7 +122,10 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(userActions.get(token, eventId))
     },
     saveUser: (token, eventId, data) => {
-      dispatch(userActions.save(token, eventId, processData(data)))
+      dispatch(userActions.save(token, eventId, data))
+    },
+    setUser: (data) => {
+      dispatch(userActions.set(data))
     }
   }
 }

--- a/dispatch/static/manager/src/js/reducers/AppReducer.js
+++ b/dispatch/static/manager/src/js/reducers/AppReducer.js
@@ -18,6 +18,7 @@ import galleriesReducer from './GalleriesReducer'
 import zonesReducer from './ZonesReducer'
 import widgetsReducer from './WidgetsReducer'
 import eventsReducer from './EventsReducer'
+import userReducer from './UserReducer'
 
 export default combineReducers({
   entities: entitiesReducer,
@@ -37,5 +38,6 @@ export default combineReducers({
   galleries: galleriesReducer,
   zones: zonesReducer,
   widgets: widgetsReducer,
-  events: eventsReducer
+  events: eventsReducer,
+  users: userReducer
 })

--- a/dispatch/static/manager/src/js/reducers/ToasterReducer.js
+++ b/dispatch/static/manager/src/js/reducers/ToasterReducer.js
@@ -185,6 +185,12 @@ export default function toasterReducer(toaster = {}, action) {
   case rejected(types.EVENTS.DELETE_MANY):
     return showToast('Some events could not be deleted', Intent.DANGER)
 
+  // Users
+  case fulfilled(types.USERS.SAVE):
+    return showToast('User saved')
+  case rejected(types.USERS.SAVE):
+    return showToast('User could not be saved', Intent.DANGER)
+
   default:
     return toaster
 

--- a/dispatch/static/manager/src/js/reducers/UserReducer.js
+++ b/dispatch/static/manager/src/js/reducers/UserReducer.js
@@ -1,0 +1,14 @@
+import { combineReducers } from 'redux'
+
+import * as types from '../constants/ActionTypes'
+
+import {
+  buildManyResourceReducer,
+  buildSingleResourceReducer
+} from '../util/redux'
+
+
+export default combineReducers({
+  list: buildManyResourceReducer(types.USERS).getReducer(),
+  single: buildSingleResourceReducer(types.USERS).getReducer(),
+})

--- a/dispatch/static/manager/src/styles/components/user_form.scss
+++ b/dispatch/static/manager/src/styles/components/user_form.scss
@@ -1,0 +1,17 @@
+@import '../utilities/colors';
+@import '../utilities/fonts';
+
+.c-user-form {
+  margin-top: 1em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+
+  border-top: 1px solid $color-border-gray;
+}
+
+.c-user-form__heading {
+  @include font-size(16);
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+  font-weight: $font-weight-bold;
+}

--- a/dispatch/static/manager/src/styles/utilities/_containers.scss
+++ b/dispatch/static/manager/src/styles/utilities/_containers.scss
@@ -38,3 +38,7 @@
 .u-container--align-left {
   padding-left: 2rem;
 }
+
+.u-container--vscroll {
+  overflow-y: auto;
+}

--- a/dispatch/tests/test_api_users.py
+++ b/dispatch/tests/test_api_users.py
@@ -269,3 +269,24 @@ class UserTests(DispatchAPITestCase):
         response = self.client.delete(url, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_retrieve_authorized_user(self):
+        """Test that retrieving the user model for the authenticated user works as expected"""
+
+        user = User.objects.get(email='test@test.com')
+
+        url = reverse('api-users-detail', args=['me'])
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(user.id, response.data['id'])
+
+    def test_retrieve_authorized_user_when_unauthenticated(self):
+        """Test that the users/me api route does not work when unauthenticated"""
+
+        self.client.credentials()
+
+        url = reverse('api-users-detail', args=['me'])
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
For the users api route, I added a feature insofar that an authenticated user can provide a keyword instead of a user id to get the authenticated user data. Since there is currently no way for the frontend to know the authenticated user's id. I chose the keyword `me` but it could be anything.

Added actions & reducer for the user model.

For the profile page itself, I reused the ProfileForm component.
Changing user name and password is an independent form with a separate submit button (since patching user is a different api call). I think this is fairly common on websites. 

There is currently no way to change the person referenced by the user, only update the person already associated. Do we want to make it changeable?

