### PR TITLE
ModelField: Fetch instances with single database call

### DIFF
--- a/dispatch/tests/test_widget_fields.py
+++ b/dispatch/tests/test_widget_fields.py
@@ -250,7 +250,7 @@ class WidgetFieldTest(DispatchAPITestCase, DispatchMediaTestMixin):
         id = -1
 
         try:
-            testfield.get_model(id)
+            testfield.get_single(id)
             self.fail('Field data is invalid, exception should have been thrown')
         except Article.DoesNotExist:
             pass
@@ -388,7 +388,7 @@ class WidgetFieldTest(DispatchAPITestCase, DispatchMediaTestMixin):
         id = 1
 
         try:
-            testfield.get_model(id)
+            testfield.get_single(id)
         except Image.DoesNotExist:
             pass
 

--- a/dispatch/theme/fields.py
+++ b/dispatch/theme/fields.py
@@ -1,5 +1,6 @@
 import json
 
+from django.db.models import Case, When
 from django.utils.dateparse import parse_datetime
 from django.core.exceptions import ObjectDoesNotExist
 
@@ -54,13 +55,10 @@ class ModelField(Field):
                 raise InvalidField('Data must be an integer')
 
     def get_many(self, ids):
-        ids_list = ','.join(map(str, ids))
+        id_order = Case(*[When(pk=pk, then=pos) for pos, pk in enumerate(ids)])
         return self.model.objects \
             .filter(pk__in=ids) \
-            .extra(
-                select={'ids': 'FIELD(%s, %s)' % (self.model._meta.pk.name, ids_list)},
-                order_by=['ids']
-            )
+            .order_by(id_order)
 
     def get_single(self, id):
         try:


### PR DESCRIPTION
This makes the `ModelField` a bit more efficient by fetching all the models with a single database call. I had to use the `extra` method to maintain the order of the selected items.