### PR TITLE
Create separate Travis build stages for testing and deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,21 @@
-language: python
-python:
-  - "2.7"
-install:
-  - pip install codecov
-  - python setup.py install
-  - pip install -e .[dev]
-script: dispatch-admin coverage
-after_success:
-  codecov
+jobs:
+  include:
+    - stage: test
+      language: python
+      python: "2.7"
+      install:
+        - pip install codecov
+        - python setup.py install
+        - pip install -e .[dev]
+      script: dispatch-admin coverage
+      after_success: codecov
+    - language: node_js
+      node_js: "6.9.5"
+      install:
+        - cd ubyssey/static
+        - npm install
+      before_script:
+        - npm install -g gulp-cli
+      script: gulp build
+    - stage: deploy
+      script: echo "DEPLOYING"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,14 @@ jobs:
         - yarn setup
       script: yarn build
     - stage: deploy
-      script: echo "DEPLOYING"
+      language: python
+      python: "2.7"
+      before_install:
+        - nvm install 6.9.5
+        - nvm use 6.9.5
+      install:
+        - cd dispatch/static/manager
+        - yarn setup
+        - yarn build
+        - cd ../../
+      script: python setup.py sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,5 @@ jobs:
       user: ubyssey
       password:
         secure: BQQSSY2KmBG4Yq8BoDIh2vHqiftXjiogU1mH6gq1fuwaAfhMnNzXK+BKnS/fqIc24cNYoFEsnH4UYQVqyDqKr/ammYBJX2+zfQtf2JqrdYaxQWZ0Fxcu7FqiWmX43nukJy7R4Yg746DJkQL15zWuk1yAzbrD+IQPzmNddFXyBF0=
+      on:
+        tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     - language: node_js
       node_js: "6.9.5"
       install:
-        - cd ubyssey/static
+        - cd dispatch/static/manager
         - npm install
       before_script:
         - npm install -g gulp-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,34 @@
 jobs:
   include:
-    - stage: test
-      language: python
-      python: "2.7"
-      install:
-        - pip install codecov
-        - python setup.py install
-        - pip install -e .[dev]
-      script: dispatch-admin coverage
-      after_success: codecov
-    - language: node_js
-      node_js: "6.9.5"
-      install:
-        - cd dispatch/static/manager
-        - yarn setup
-      script: yarn build
-    - stage: deploy
-      language: python
-      python: "2.7"
-      before_install:
-        - nvm install 6.9.5
-        - nvm use 6.9.5
-      install:
-        - cd dispatch/static/manager
-        - yarn setup
-        - yarn build
-        - cd ../../../
-      script: python setup.py sdist
+  - stage: test
+    language: python
+    python: '2.7'
+    install:
+    - pip install codecov
+    - python setup.py install
+    - pip install -e .[dev]
+    script: dispatch-admin coverage
+    after_success: codecov
+  - language: node_js
+    node_js: 6.9.5
+    install:
+    - cd dispatch/static/manager
+    - yarn setup
+    script: yarn build
+  - stage: deploy
+    language: python
+    python: '2.7'
+    before_install:
+    - nvm install 6.9.5
+    - nvm use 6.9.5
+    install:
+    - cd dispatch/static/manager
+    - yarn setup
+    - yarn build
+    - cd ../../../
+    script: python setup.py sdist
+    deploy:
+      provider: pypi
+      user: ubyssey
+      password:
+        secure: BQQSSY2KmBG4Yq8BoDIh2vHqiftXjiogU1mH6gq1fuwaAfhMnNzXK+BKnS/fqIc24cNYoFEsnH4UYQVqyDqKr/ammYBJX2+zfQtf2JqrdYaxQWZ0Fxcu7FqiWmX43nukJy7R4Yg746DJkQL15zWuk1yAzbrD+IQPzmNddFXyBF0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ jobs:
       node_js: "6.9.5"
       install:
         - cd dispatch/static/manager
-        - npm install
-      before_script:
-        - npm install -g gulp-cli
-      script: gulp build
+        - yarn setup
+      script: yarn build
     - stage: deploy
       script: echo "DEPLOYING"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ jobs:
         - cd dispatch/static/manager
         - yarn setup
         - yarn build
-        - cd ../../
+        - cd ../../../
       script: python setup.py sdist


### PR DESCRIPTION
The build process now has three separate stages: two testing stages and a final deployment stage. 

The testing stages run in parallel (one for Python, one for JS) and the deployment stage only runs if both testing stages pass. The deployment stage builds the package and pushes it directly to PyPI if a new tag has been created.