### PR TITLE
Gallery title now displayed at top of gallery edit page (fixes #735)

### DIFF
--- a/dispatch/static/manager/src/js/components/GalleryEditor/index.js
+++ b/dispatch/static/manager/src/js/components/GalleryEditor/index.js
@@ -62,6 +62,7 @@ function TopicEditorComponent(props) {
       type={TYPE}
       afterDelete={AFTER_DELETE}
       form={GalleryForm}
+      displayField='title'
       {... props} />
   )
 }


### PR DESCRIPTION
Close #735 