### PR TITLE
Fixed Firefox image manager - broken flexbox

### DIFF
--- a/dispatch/static/manager/src/styles/components/image_manager.scss
+++ b/dispatch/static/manager/src/styles/components/image_manager.scss
@@ -58,6 +58,8 @@ $image-manager-footer-box-shadow: rgba(0,0,0,0.05) 0px -1px 1px;
   // Structure
   display: flex;
   flex: 1;
+  min-width: 0;
+  min-height: 0;
 }
 
 .c-image-manager__images {


### PR DESCRIPTION
Firefox requires a `min-height` and `min-width` setting for flexbox scrolling to work properly (apparently [Chrome might soon require this](https://stackoverflow.com/questions/28636832/firefox-overflow-y-not-working-with-nested-flexbox)  so it's good future-proofing).