### PR TITLE
Move the logic from ArticleHelper to PublishableManager

### DIFF
--- a/dispatch/modules/content/managers.py
+++ b/dispatch/modules/content/managers.py
@@ -15,16 +15,17 @@ class PublishableManager(Manager):
 
         Otherwise, get the published version of the article.
         """
-        
-        request = args[0]
+        kwargs['is_published'] = True
 
-        version = request.GET.get('version', None)
-        preview_id = request.GET.get('preview_id', None)
+        if len(args) > 0:
+        	request = args[0]
 
-        if (version is not None) and (preview_id is not None):
-        	kwargs['revision_id'] = version
-        	kwargs['preview_id'] = preview_id    
-        else:
-        	kwargs['is_published'] = True
+        	version = request.GET.get('version', None)
+        	preview_id = request.GET.get('preview_id', None)
+
+        	if (version is not None) and (preview_id is not None):
+        		kwargs['revision_id'] = version
+        		kwargs['preview_id'] = preview_id
+        		del kwargs['is_published']
 
         return super(PublishableManager, self).get(**kwargs)

--- a/dispatch/modules/content/managers.py
+++ b/dispatch/modules/content/managers.py
@@ -15,7 +15,6 @@ class PublishableManager(Manager):
 
         Otherwise, get the published version of the article.
         """
-        kwargs['is_published'] = True
 
         if len(args) > 0:
         	request = args[0]

--- a/dispatch/modules/content/managers.py
+++ b/dispatch/modules/content/managers.py
@@ -9,4 +9,22 @@ class PublishableManager(Manager):
             kwargs['parent'] = kwargs['pk']
             kwargs['head'] = True
             del kwargs['pk']
-        return super(PublishableManager, self).get(*args, **kwargs)
+
+        """If the url requested includes the querystring parameters 'version' and 'preview_id',
+        get the article with the specified version and preview_id.
+
+        Otherwise, get the published version of the article.
+        """
+        
+        request = args[0]
+
+        version = request.GET.get('version', None)
+        preview_id = request.GET.get('preview_id', None)
+
+        if (version is not None) and (preview_id is not None):
+        	kwargs['revision_id'] = version
+        	kwargs['preview_id'] = preview_id    
+        else:
+        	kwargs['is_published'] = True
+
+        return super(PublishableManager, self).get(**kwargs)

--- a/dispatch/modules/content/managers.py
+++ b/dispatch/modules/content/managers.py
@@ -16,15 +16,16 @@ class PublishableManager(Manager):
         Otherwise, get the published version of the article.
         """
 
-        if len(args) > 0:
-        	request = args[0]
+        if 'request' in kwargs:
+	       	request = kwargs['request']
+	       	version = request.GET.get('version', None)
+	       	preview_id = request.GET.get('preview_id', None)
 
-        	version = request.GET.get('version', None)
-        	preview_id = request.GET.get('preview_id', None)
+	       	if (version is not None) and (preview_id is not None):
+	       		kwargs['revision_id'] = version
+	       		kwargs['preview_id'] = preview_id
+	       		del kwargs['is_published']
 
-        	if (version is not None) and (preview_id is not None):
-        		kwargs['revision_id'] = version
-        		kwargs['preview_id'] = preview_id
-        		del kwargs['is_published']
+	       	del kwargs['request']
 
-        return super(PublishableManager, self).get(**kwargs)
+        return super(PublishableManager, self).get(*args, **kwargs)


### PR DESCRIPTION
Close ubyssey/ubyssey.ca#390

So I'm not entirely sure if this is what you had in mind, but I relocated all the logic (for deciding whether to get the published or the preview version of the article) from ArticleHelper in helpers.py (ubyssey.ca repo) to PublishableManager in managers.py (dispatch repo).

Let me know what you think!