### PR TITLE
Fix event approve button

### DIFF
--- a/dispatch/static/manager/src/js/pages/Events/EventAuditPage.js
+++ b/dispatch/static/manager/src/js/pages/Events/EventAuditPage.js
@@ -69,7 +69,7 @@ class EventAuditPage extends React.Component {
 
   approve(id) {
     this.checkPage()
-    this.props.approveEvent(this.props.token, id)
+    this.props.approveAndPublishEvent(this.props.token, id)
   }
 
   disapprove(id) {


### PR DESCRIPTION
A small fix for the event approval button -- it was being linked to the wrong action.