### PR TITLE
Fix subsection page

### DIFF
--- a/dispatch/api/serializers.py
+++ b/dispatch/api/serializers.py
@@ -755,8 +755,7 @@ class ArticleSerializer(DispatchModelSerializer, DispatchPublishableSerializer):
             instance.save_topic(topic_id)
 
         subsection_id = validated_data.get('subsection_id', None)
-        if subsection_id is not None:
-            instance.save_subsection(subsection_id)
+        instance.save_subsection(subsection_id)
 
         # Perform a final save (without revision), update content and featured image
         instance.save(

--- a/dispatch/modules/content/models.py
+++ b/dispatch/modules/content/models.py
@@ -417,8 +417,8 @@ class Subsection(Model, AuthorMixin):
         return Article.objects.filter(subsection=self, id=F('parent_id'))
 
     def get_published_articles(self):
-        return Article.objects.filter(subsection=self, is_published=True).order_by('-published_at')[:3]
-        
+        return Article.objects.filter(subsection=self, is_published=True).order_by('-published_at')
+
     def get_absolute_url(self):
         """ Returns the subsection URL. """
         return "%s%s/" % (settings.BASE_URL, self.slug)

--- a/dispatch/modules/content/models.py
+++ b/dispatch/modules/content/models.py
@@ -417,8 +417,8 @@ class Subsection(Model, AuthorMixin):
         return Article.objects.filter(subsection=self, id=F('parent_id'))
 
     def get_published_articles(self):
-        return Article.objects.filter(subsection=self, is_published=True)
-
+        return Article.objects.filter(subsection=self, is_published=True).order_by('-published_at')[:3]
+        
     def get_absolute_url(self):
         """ Returns the subsection URL. """
         return "%s%s/" % (settings.BASE_URL, self.slug)

--- a/dispatch/static/manager/src/js/components/ArticleEditor/ArticleSidebar.js
+++ b/dispatch/static/manager/src/js/components/ArticleEditor/ArticleSidebar.js
@@ -49,6 +49,7 @@ class ArticleSidebar extends React.Component {
                 authors={this.props.article.authors || []}
                 tags={this.props.article.tags || []}
                 topic={this.props.article.topic}
+                subsection={this.props.article.subsection}
                 slug={this.props.article.slug}
                 snippet={this.props.article.snippet}
                 errors={this.props.errors} />


### PR DESCRIPTION
 - fix invocation of save_subsection in article serializer to be able to remove a subsection
 - add ordering by published_at to get_published_articles in subsection model
 - add missing prop to basicfieldstab in articlesidebar.js so that selected subsection shows up properly