### PR TITLE
Fix new article page from dashboard

### DIFF
--- a/dispatch/static/manager/src/js/components/Editor/tabs/TemplateTab.js
+++ b/dispatch/static/manager/src/js/components/Editor/tabs/TemplateTab.js
@@ -26,7 +26,7 @@ class TemplateTabComponent extends React.Component {
     const template = this.props.entities.templates[this.props.template] || null
     const fields = (
       <FieldGroup
-        name={`template-field__${template.id}`}
+        name={`template-field__${template ? template.id : null}`}
         fields={(this.props.data ? (template ? template.fields : []) : null)}
         data={this.props.data}
         errors={this.props.errors}


### PR DESCRIPTION
check if template exists before accessing. This fixes refreshing the new article page as well as navigating to new article page from the dashboard