### PR TITLE
883 Adds --help Command to dispatch-admin

### DIFF
--- a/dispatch/bin/dispatch-admin
+++ b/dispatch/bin/dispatch-admin
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import os
 import sys
 import dispatch

--- a/dispatch/bin/dispatch-admin
+++ b/dispatch/bin/dispatch-admin
@@ -1,8 +1,13 @@
 #!/usr/bin/env python
+
 import os
 import sys
 import dispatch
 import coverage
+
+from dispatch.resources import messages as messages
+from docopt import docopt
+from pprint import pprint
 
 import django
 from django.conf import settings
@@ -62,6 +67,11 @@ def coverage_html_report():
     cov.load()
     cov.html_report()
 
+def show_help():
+    #Show help
+    message = docopt(messages.DISPATCH_ADMIN_HELP_TEXT, version = dispatch.__version__)
+    pprint(message)
+
 commands = {
     'test': run_tests,
     'coverage': run_coverage,
@@ -78,7 +88,7 @@ if __name__ == "__main__":
     try:
         func = commands[command_name]
     except KeyError:
-        print "%s isn't a valid command" % command_name
+        show_help()
         exit()
 
     # Execute the function

--- a/dispatch/resources/messages.py
+++ b/dispatch/resources/messages.py
@@ -1,0 +1,18 @@
+import dispatch
+
+DISPATCH_ADMIN_HELP_TEXT = """
+Dispatch Admin """+ dispatch.__version__ + """
+
+Usage: 
+    dispatch-admin <OPTION> <ARGUMENT>
+
+ Options:
+    test            Run tests
+    coverage        Run coverage
+    report          Generate coverage report
+    report_html     Generate html coverage report
+   -h, --help       Print this help message and exit
+   --version        Print product version and exit
+
+See https://github.com/ubyssey/dispatch for more details
+"""


### PR DESCRIPTION
Fixes #883 

This gives a simple implementation of the `--help` and `--version` functionality for the `dispatch-admin` using `docopt`. Please feel free to develop improvements on top of this. 

**Added Commands** 
```
dispatch-admin -h
dispatch-admin --help
dispatch-admin --version
```

Every other command other than the supported commands should return the default usage section.

**Added Help Text**

```
Dispatch Admin 0.5.16

Usage: 
    dispatch-admin <OPTION> <ARGUMENT>

 Options:
    test            Run tests
    coverage        Run coverage
    report          Generate coverage report
    report_html     Generate html coverage report
   -h, --help       Print this help message and exit
   --version        Print product version and exit

See https://github.com/ubyssey/dispatch for more details
```