### PR TITLE
Show images from newest

### DIFF
--- a/dispatch/api/views.py
+++ b/dispatch/api/views.py
@@ -334,7 +334,7 @@ class ImageViewSet(viewsets.ModelViewSet):
     update_fields = ('title', 'authors', 'tags')
 
     def get_queryset(self):
-        queryset = Image.objects.all()
+        queryset = Image.objects.order_by('-updated_at')
 
         author = self.request.query_params.get('author', None)
         tags = self.request.query_params.getlist('tags', None)

--- a/dispatch/tests/test_api_images.py
+++ b/dispatch/tests/test_api_images.py
@@ -279,9 +279,9 @@ class ImagesTests(DispatchAPITestCase, DispatchMediaTestMixin):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 3)
-        self.assertEqual(response.data['results'][0]['filename'], image_1.data['filename'])
+        self.assertEqual(response.data['results'][0]['filename'], image_3.data['filename'])
         self.assertEqual(response.data['results'][1]['filename'], image_2.data['filename'])
-        self.assertEqual(response.data['results'][2]['filename'], image_3.data['filename'])
+        self.assertEqual(response.data['results'][2]['filename'], image_1.data['filename'])
 
     def test_tag_query(self):
         """Should be able to search images by tags"""
@@ -323,8 +323,8 @@ class ImagesTests(DispatchAPITestCase, DispatchMediaTestMixin):
         data = response.data
 
         self.assertEqual(data['count'], 2)
-        self.assertEqual(data['results'][0]['filename'], 'test_image_a.jpg')
-        self.assertEqual(data['results'][1]['filename'], 'test_image_a.jpeg')
+        self.assertEqual(data['results'][0]['filename'], 'test_image_a.jpeg')
+        self.assertEqual(data['results'][1]['filename'], 'test_image_a.jpg')
 
     def test_author_query(self):
         """Should be able to search images by authors"""
@@ -366,8 +366,8 @@ class ImagesTests(DispatchAPITestCase, DispatchMediaTestMixin):
         data = response.data
 
         self.assertEqual(data['count'], 2)
-        self.assertEqual(data['results'][0]['filename'], 'test_image_a.jpg')
-        self.assertEqual(data['results'][1]['filename'], 'test_image_a.jpeg')
+        self.assertEqual(data['results'][0]['filename'], 'test_image_a.jpeg')
+        self.assertEqual(data['results'][1]['filename'], 'test_image_a.jpg')
 
     def test_name_query(self):
         """Should be able to search images by name"""
@@ -390,6 +390,6 @@ class ImagesTests(DispatchAPITestCase, DispatchMediaTestMixin):
 
         data = response.data
 
-        self.assertEqual(data['results'][0]['filename'], 'test_image_b.jpg')
-        self.assertEqual(data['results'][1]['filename'], 'test_image_b.jpeg')
+        self.assertEqual(data['results'][0]['filename'], 'test_image_b.jpeg')
+        self.assertEqual(data['results'][1]['filename'], 'test_image_b.jpg')
         self.assertEqual(data['count'], 2)


### PR DESCRIPTION
Old `/images` pages shows the images from newest to oldest, but this pr changes to the other way as described in #897 
## Before
![image](https://user-images.githubusercontent.com/9669739/48604721-96f25a00-e92f-11e8-93fc-1b1a8a7df3ce.png)
