### PR TITLE
Fix gallaery image popover placement

### DIFF
--- a/dispatch/static/manager/src/js/components/GalleryEditor/GalleryForm.js
+++ b/dispatch/static/manager/src/js/components/GalleryEditor/GalleryForm.js
@@ -210,7 +210,7 @@ class GalleryFormComponent extends React.Component {
                 className='c-gallery-thumb-overlay'
                 style={{
                   width: THUMB_WIDTH,
-                  height: THUMB_HEIGHT
+                  height: 0
                 }}>
                 <div className='c-gallery-thumb-overlay-text'>
                   {i++}
@@ -275,7 +275,7 @@ class GalleryFormComponent extends React.Component {
             Clear Gallery
           </Button>
         </div>
-        
+
       </Form.Container>
     )
   }


### PR DESCRIPTION
Fix #899 

## After

![image](https://user-images.githubusercontent.com/9669739/48606186-d1f68c80-e933-11e8-8c07-8b702e9fb40b.png)
