### PR TITLE
add filter by query to the TemplateViewSet

### DIFF
--- a/dispatch/api/validators.py
+++ b/dispatch/api/validators.py
@@ -101,9 +101,7 @@ def TemplateValidator(template, template_data, tags):
                 except KeyError:
                     pass
                 except InvalidField as e:
-                    print(field.name)
                     if (field.name == 'next_article'):
-                        print("next_article is true")
                         continue
                     if (field.name == 'article_first'):
                         continue
@@ -112,7 +110,6 @@ def TemplateValidator(template, template_data, tags):
                     if (field.name == 'article_third'):
                         continue
                     else:
-                        print("else on ", e)
                         errors[field.name] = str(e)
         else:
             for field in template.fields:

--- a/dispatch/api/views.py
+++ b/dispatch/api/views.py
@@ -424,7 +424,14 @@ class TemplateViewSet(viewsets.GenericViewSet):
         })
 
     def list(self, request):
-        templates = ThemeManager.Templates.list()
+        q = self.request.query_params.get('q', None)
+
+        if q is not None:
+            templates = filter(lambda x: x.name.lower().__contains__(q.lower()), ThemeManager.Templates.list())
+
+        else:
+            templates = ThemeManager.Templates.list()
+
         serializer = TemplateSerializer(templates, many=True)
         return self.get_paginated_response(serializer.data)
 

--- a/dispatch/static/manager/src/js/components/inputs/selects/ItemSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/selects/ItemSelectInput.js
@@ -93,6 +93,12 @@ class ItemSelectInput extends React.Component {
     }
   }
 
+  openDropdown() {
+    this.refs.dropdown.open()
+    if (this.state.query === '' || !this.state.query) 
+      this.fetchResults()
+  }
+
   closeDropdown() {
     this.refs.dropdown.close()
     this.setState({ query: '' })
@@ -216,7 +222,7 @@ class ItemSelectInput extends React.Component {
     const selected = this.getSelected()
 
     const Button = (
-      <a onClick={() => this.refs.dropdown.open()}>
+      <a onClick={() => this.openDropdown()}>
         {this.props.editMessage}
       </a>
     )
@@ -231,7 +237,7 @@ class ItemSelectInput extends React.Component {
           this.clearValues()
           e.stopPropagation()
         }}
-        onClick={() => this.refs.dropdown.open()}>
+        onClick={() => this.openDropdown()}>
           {this.props.editMessage}
       </Tag>
     ) : (
@@ -240,7 +246,7 @@ class ItemSelectInput extends React.Component {
         round={true}
         icon={this.props.icon}
         interactive={true}
-        onClick={() => this.refs.dropdown.open()}>
+        onClick={() => this.openDropdown()}>
           {this.props.editMessage}
       </Tag>
     )


### PR DESCRIPTION
Removes some leftover print statements from `TemplateValidator`
Filters the list of Templates with the query params from the frontend.
Triggers a fetch on an empty query to initially show the full list of templates when dropdown opened.


![screencast 2018-12-18 13_34_33](https://user-images.githubusercontent.com/19273530/50184464-0e6a2f00-02ca-11e9-8aa5-60850392805f.gif)
