### PR TITLE
add sections column to the articles index page

### DIFF
--- a/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Articles/ArticleIndexPage.js
@@ -77,10 +77,11 @@ function ArticlePageComponent(props) {
       displayColumn='headline'
       filters={filters}
       hasFilters={hasFilters}
-      headers={[ 'Headline', '', 'Authors', 'Published', 'Revisions']}
+      headers={[ 'Headline', '', 'Section', 'Authors', 'Published', 'Revisions']}
       exclude={'subsection,subsection_id'}
       extraColumns={[
         item => item.currently_breaking ? breakingNews : '',
+        item => props.entities.sections[item.section]['name'],
         item => item.authors_string,
         item => item.published_at ? humanizeDatetime(item.published_at) : 'Unpublished',
         item => item.latest_version + ' revisions' 


### PR DESCRIPTION
#910 

There is now a sections column on the `ArticleIndexPage` component.

![image](https://user-images.githubusercontent.com/19273530/53994147-56893880-40e6-11e9-8f3c-01f50d68fc52.png)
