### PR TITLE
Add 'overflow: auto' to image filename'

### DIFF
--- a/dispatch/static/manager/src/js/components/modals/ImageManager/ImagePanel.js
+++ b/dispatch/static/manager/src/js/components/modals/ImageManager/ImagePanel.js
@@ -25,7 +25,7 @@ export default function ImagePanel(props) {
         <img className='c-image-panel__image__img' src={props.image.url_medium} />
         <div className='c-image-panel__image__filename'>{props.image.filename}</div>
       </div>
-      <form>
+      <form className='c-image-panel__form'>
         <Form.Input label='Title'>
           <TextInput
             value={props.image.title || ''}

--- a/dispatch/static/manager/src/styles/components/image_manager.scss
+++ b/dispatch/static/manager/src/styles/components/image_manager.scss
@@ -106,7 +106,7 @@ $image-manager-footer-box-shadow: rgba(0,0,0,0.05) 0px -1px 1px;
 .c-image-manager__active {
   // Structure
   flex: 1;
-  overflow: scroll;
+  overflow-y: scroll;
 
   // Border
   border-left: 1px solid $color-border-gray;

--- a/dispatch/static/manager/src/styles/components/image_panel.scss
+++ b/dispatch/static/manager/src/styles/components/image_panel.scss
@@ -48,3 +48,7 @@
   color: $color-black;
   line-height: 1.3em;
 }
+
+.c-image-panel__form {
+  margin: 10px;
+}

--- a/dispatch/static/manager/src/styles/components/image_panel.scss
+++ b/dispatch/static/manager/src/styles/components/image_panel.scss
@@ -41,6 +41,7 @@
   // Border
   border: thin solid $color-border-gray;
   border-top: none;
+  overflow: auto;
 
   // Text
   @include font-size(13);


### PR DESCRIPTION
## Problem
![image](https://user-images.githubusercontent.com/9669739/54481286-039f3780-47f0-11e9-8a2f-f331766de987.png)

Editors tend to upload pictures with camera default name (ex. "zubair_XYZXYZYXZYXYZXYZ_ABCABCABC") which overflows the image picker preview div

![image](https://user-images.githubusercontent.com/9669739/54481443-df445a80-47f1-11e9-92ee-abb4a1706eeb.png)

Also the image-panel's have x-axis scroll bar by default when we don't need one. This takes away limited space in image-panel so should be removed. No padding right now in the form as well so things are kinda tight.

## After

![image](https://user-images.githubusercontent.com/9669739/54481473-5f6ac000-47f2-11e9-92ae-1fdb87ab2a36.png)

Cleaner
