### PR TITLE
Add stripe overlay & use green border for img manager

### DIFF
--- a/dispatch/static/manager/src/js/components/modals/ImageManager/ImageThumb.js
+++ b/dispatch/static/manager/src/js/components/modals/ImageManager/ImageThumb.js
@@ -4,8 +4,22 @@ require('../../../../styles/components/image_thumb.scss')
 
 export default function ImageThumb(props) {
 
-  const style = {
-    backgroundImage: `url('${props.image.url_thumb}')`
+  let style
+
+  if (props.isSelected) {
+    style = {
+      background: `repeating-linear-gradient(
+        45deg,
+        rgba(0, 0, 0, 0.2),
+        rgba(0, 0, 0, 0.2) 10px,
+        rgba(0, 0, 0, 0.3) 10px,
+        rgba(0, 0, 0, 0.3) 20px
+      ), url('${props.image.url_thumb}'), center center`
+    }
+  } else {
+    style = {
+      background: `url('${props.image.url_thumb}'), center center`
+    }
   }
 
   const baseClass = 'c-image-thumb'

--- a/dispatch/static/manager/src/js/components/modals/ImageManager/index.js
+++ b/dispatch/static/manager/src/js/components/modals/ImageManager/index.js
@@ -193,6 +193,7 @@ class ImageManagerComponent extends React.Component {
         <div className='c-image-manager__footer'>
           <div className='c-image-manger__footer__selected' />
           <Button
+            intent={Intent.SUCCESS}
             disabled={this.props.many ? !this.props.images.selected.length : !this.props.image.id}
             onClick={() => this.insertImage()}>Insert</Button>
         </div>

--- a/dispatch/static/manager/src/styles/components/image_thumb.scss
+++ b/dispatch/static/manager/src/styles/components/image_thumb.scss
@@ -16,7 +16,7 @@
   }
 
   &--selected .c-image-thumb__inner {
-    outline: 2px solid red;
+    outline: 4px solid #1d9f6a;
   }
 }
 


### PR DESCRIPTION
## What problem does this PR solve?

![image](https://user-images.githubusercontent.com/9669739/54486524-aedadb80-4846-11e9-8338-bb6109020d1f.png)

I find myself always losing where the current focus is in the image manager UI.
 PR aims to make it visually easier to spot

![image](https://user-images.githubusercontent.com/9669739/54486538-cade7d00-4846-11e9-8263-7e2df9f03b0d.png)

Similarly, the insert btn is the primary action when inserting an img to an article, but the color isn't highlighted rn

## How did you fix the problem?

![image](https://user-images.githubusercontent.com/9669739/54486544-e77ab500-4846-11e9-9dbe-8c412df318d5.png)

- Changed border thickness from 2px to 4px
- Use green instead of red to communicate success state (or vibe?)
- Added stripe CSS overlay

![image](https://user-images.githubusercontent.com/9669739/54486548-04af8380-4847-11e9-88d3-9072d0a08393.png)

- Make the insert btn be highlighted as primary action

## Before

![image](https://user-images.githubusercontent.com/9669739/54486562-2577d900-4847-11e9-87a6-81768c10c322.png)

## After

![image](https://user-images.githubusercontent.com/9669739/54486640-1cd3d280-4848-11e9-9f94-1e04d7302b31.png)

Feedback welcome