### PR TITLE
Add rss feed copy to clipboard feature on podcasts

### DIFF
--- a/dispatch/static/manager/src/js/components/CopyToClipboard.js
+++ b/dispatch/static/manager/src/js/components/CopyToClipboard.js
@@ -1,15 +1,21 @@
 import React from 'react'
+import Tooltip from '../components/Tooltip'
 
-class CopyToClipboard extends React.Component{
-  render(){
+require('../../styles/components/tooltip.scss')
+require('../../styles/components/copy_to_clipboard.scss')
+
+class CopyToClipboard extends React.Component {
+  render() {
     return (
-      <div>
+      <div className="c-copy-container">
         <textarea
-          ref={(node) => { this.txtInput=node }}
+          ref={(node) => { this.txtInput = node }}
           value={this.props.text} />
-        <button 
-          className="bp3-button bp3-icon-large bp3-icon-clipboard" 
-          onClick={() => { this.txtInput.select(); document.execCommand('copy')}} />
+        <Tooltip text={'Copied!'} position={'top'} activateOnClick>
+          <button
+            className="bp3-button bp3-icon-medium bp3-icon-clipboard"
+            onClick={() => { this.txtInput.select(); document.execCommand('copy') }} />
+        </Tooltip>
       </div>
     )
   }

--- a/dispatch/static/manager/src/js/components/CopyToClipboard.js
+++ b/dispatch/static/manager/src/js/components/CopyToClipboard.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+class CopyToClipboard extends React.Component{
+  render(){
+    return (
+      <div className="cols">
+        <textarea
+          ref={(node) => { this.txtInput=node }}
+          value={this.props.text} />
+        <button 
+          className="center bp3-button bp3-icon-large bp3-icon-clipboard" 
+          onClick={() => { this.txtInput.select(); document.execCommand('copy')}} />
+      </div>
+    )
+  }
+}
+
+export default CopyToClipboard

--- a/dispatch/static/manager/src/js/components/CopyToClipboard.js
+++ b/dispatch/static/manager/src/js/components/CopyToClipboard.js
@@ -3,12 +3,12 @@ import React from 'react'
 class CopyToClipboard extends React.Component{
   render(){
     return (
-      <div className="cols">
+      <div>
         <textarea
           ref={(node) => { this.txtInput=node }}
           value={this.props.text} />
         <button 
-          className="center bp3-button bp3-icon-large bp3-icon-clipboard" 
+          className="bp3-button bp3-icon-large bp3-icon-clipboard" 
           onClick={() => { this.txtInput.select(); document.execCommand('copy')}} />
       </div>
     )

--- a/dispatch/static/manager/src/js/components/CopyToClipboard.js
+++ b/dispatch/static/manager/src/js/components/CopyToClipboard.js
@@ -11,7 +11,7 @@ class CopyToClipboard extends React.Component {
         <textarea
           ref={(node) => { this.txtInput = node }}
           value={this.props.text} />
-        <Tooltip text={'Copied!'} position={'top'} activateOnClick>
+        <Tooltip text={'Copied!'} position={'top'} activateOnClick={true}>
           <button
             className="bp3-button bp3-icon-medium bp3-icon-clipboard"
             onClick={() => { this.txtInput.select(); document.execCommand('copy') }} />

--- a/dispatch/static/manager/src/js/components/Tooltip.js
+++ b/dispatch/static/manager/src/js/components/Tooltip.js
@@ -1,0 +1,44 @@
+import React from 'react'
+
+class Tooltip extends React.Component{
+  constructor(props) {
+    super(props)
+    
+    this.state = {
+      isTooltipDisplayed: false
+    }
+    
+    this.hideTooltip = this.hideTooltip.bind(this)
+    this.showTooltip = this.showTooltip.bind(this)
+  }
+
+  hideTooltip () {
+    this.setState({isTooltipDisplayed: false})
+  }
+      
+  showTooltip () {
+    this.setState({isTooltipDisplayed: true})
+  }
+    
+  render(){
+    return (
+      <div
+        className='tooltip'
+        onMouseLeave={this.hideTooltip}>
+        
+        {this.state.isTooltipDisplayed &&
+          <div className={`tooltip-bubble tooltip-${this.props.position}`}>
+            <div className='tooltip-text'>{this.props.text}</div>
+          </div>
+        }
+        
+        {this.props.activateOnClick ? 
+          <span className='tooltip-trigger' onClick={this.showTooltip}> {this.props.children}</span> :
+          <span className='tooltip-trigger' onMouseOver={this.showTooltip}> {this.props.children}</span>
+        }
+      </div>
+    )
+  }
+}
+
+export default Tooltip

--- a/dispatch/static/manager/src/js/pages/Podcasts/PodcastIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Podcasts/PodcastIndexPage.js
@@ -5,6 +5,7 @@ import { Link } from 'react-router'
 
 import ItemIndexPage from '../ItemIndexPage'
 import podcastsActions from '../../actions/PodcastsActions'
+import CopyToClipboard from '../../components/CopyToClipboard'
 
 const mapStateToProps = (state) => {
   return {
@@ -59,14 +60,18 @@ function PodcastsPageComponent(props) {
     </strong>
   )
 
+  const rssFeedColumn = (item) => (
+    <CopyToClipboard text={`${window.location.origin}/podcasts/${item.slug}/`}/>
+  )
+
   return (
     <ItemIndexPage
       typeSingular='podcast'
       typePlural='podcasts'
       displayColumn='title'
       pageTitle='Podcasts'
-      headers={['Title']}
-      columns={[titleColumn]}
+      headers={['Title', 'Rss Feed']}
+      columns={[titleColumn, rssFeedColumn]}
       {... props} />
   )
 }

--- a/dispatch/static/manager/src/js/pages/Podcasts/PodcastIndexPage.js
+++ b/dispatch/static/manager/src/js/pages/Podcasts/PodcastIndexPage.js
@@ -61,7 +61,7 @@ function PodcastsPageComponent(props) {
   )
 
   const rssFeedColumn = (item) => (
-    <CopyToClipboard text={`${window.location.origin}/podcasts/${item.slug}/`}/>
+    <CopyToClipboard text={`${window.location.origin}/podcasts/${item.slug}/`} />
   )
 
   return (

--- a/dispatch/static/manager/src/styles/components/copy_to_clipboard.scss
+++ b/dispatch/static/manager/src/styles/components/copy_to_clipboard.scss
@@ -1,0 +1,4 @@
+.c-copy-container {
+  display: inline-flex;
+  margin-block-start: 5px;
+}

--- a/dispatch/static/manager/src/styles/components/tooltip.scss
+++ b/dispatch/static/manager/src/styles/components/tooltip.scss
@@ -1,0 +1,97 @@
+$tooltip-color: rgba(0,0,0,.7);
+$tooltip-text-color: #fff;
+
+.tooltip {
+  position: relative;
+  margin-left: 5px;
+}
+
+.tooltip-trigger {
+  display: inline-block;
+  text-decoration: underline;
+}
+
+.tooltip-bubble {
+  min-width: 120px;
+  max-width: 210px;
+  position: absolute;
+  z-index: 10;
+  &::after {
+    content: '';
+    position: absolute;
+  }
+}
+
+.tooltip-top {
+  bottom: 100%;
+  left: 50%;
+  padding-bottom: 9px;
+  transform: translateX(-50%);
+  
+  &::after {
+    border-left: 9px solid transparent;
+    border-right: 9px solid transparent;
+    border-top: 9px solid $tooltip-color;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
+.tooltip-bottom {
+  top: 100%;
+  left: 50%;
+  padding-top: 9px;
+  transform: translateX(-50%);
+  
+  &::after {
+    border-left: 9px solid transparent;
+    border-right: 9px solid transparent;
+    border-bottom: 9px solid $tooltip-color;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+
+.tooltip-left {
+  top: 50%;
+  right: 100%;
+  padding-right: 9px;
+  transform: translateY(-50%);
+  
+  &::after {
+    border-left: 9px solid $tooltip-color;
+    border-top: 9px solid transparent;
+    border-bottom: 9px solid transparent;
+    top: 50%;
+    right: 0;
+    transform: translateY(-50%);
+  }
+}
+
+.tooltip-right {
+  top: 50%;
+  left: 100%;
+  padding-left: 9px;
+  transform: translateY(-50%);
+  
+  &::after {
+    border-right: 9px solid $tooltip-color;
+    border-top: 9px solid transparent;
+    border-bottom: 9px solid transparent;
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+  }
+}
+
+.tooltip-text {
+  background: $tooltip-color;
+  border-radius: 3px;
+  color: $tooltip-text-color;
+  font-size: .75rem;
+  line-height: 1.4;
+  padding: .75em;
+  text-align: center;
+}


### PR DESCRIPTION
## What problem does this PR solve?

This PR solves the issue (#903 ) of not having an RSS feed on the podcasts page.

## How did you fix the problem?

Created & used a CopyToClipboard Component, which uses the newly added Tooltip component. Tooltips can be activated on click or on hover. They can be positioned top, bottom, right, left.