### PR TITLE
Add version tooltip under dispatch logo

### DIFF
--- a/dispatch/static/manager/src/js/components/Header/Header.js
+++ b/dispatch/static/manager/src/js/components/Header/Header.js
@@ -6,9 +6,11 @@ import { Button } from '@blueprintjs/core'
 import HeaderButtons from './HeaderButtons'
 import MobileHeaderButtons from './MobileHeaderButtons'
 import { desktopSize } from '../../util/helpers'
+import Tooltip from '../../components/Tooltip'
 
 require('../../../styles/components/header.scss')
 require('../../../styles/components/loading_bar.scss')
+require('../../../styles/components/tooltip.scss')
 
 class Header extends React.Component {
   constructor(props) {
@@ -20,13 +22,18 @@ class Header extends React.Component {
   }
 
   renderLink(url, classes, icon, value, subscript) {
+    if (subscript) {
+      value = (<Tooltip text={`${subscript}`} position={'bottom'} activateOnClick={false}>
+        {value}
+        </Tooltip>)
+    }
+  
     return (
       <Button
         minimal={true}
         onClick={() => this.props.goTo(url)}
         icon={icon}>
         {value}
-        {subscript && <div className='dispatch-version'>{subscript}</div>}
       </Button>
     )
   }

--- a/dispatch/static/manager/src/styles/components/tooltip.scss
+++ b/dispatch/static/manager/src/styles/components/tooltip.scss
@@ -8,7 +8,6 @@ $tooltip-text-color: #fff;
 
 .tooltip-trigger {
   display: inline-block;
-  text-decoration: underline;
 }
 
 .tooltip-bubble {


### PR DESCRIPTION
## What problem does this PR solve?

This PR solves the issue (#865 ) about displaying the dispatch version under the dispatch logo.

## How did you fix the problem?

Added a tooltip conditionally, depending on whether we have the subscript available (the subscript in this context would be the dispatch version). The tooltip was added on the text "dispatch". Removed the underline effect of the tooltips.