### PR TITLE
[Security] Update Django to 1.11.19

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='dispatch',
     scripts=['dispatch/bin/dispatch-admin'],
     include_package_data=True,
     install_requires=[
-        'django == 1.11.19',
+        'django == 1.11.20',
         'djangorestframework == 3.6.2',
         'pillow',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='dispatch',
     scripts=['dispatch/bin/dispatch-admin'],
     include_package_data=True,
     install_requires=[
-        'django == 1.11',
+        'django == 1.11.19',
         'djangorestframework == 3.6.2',
         'pillow',
         'requests',


### PR DESCRIPTION
GitHub have been warning that we need to update django version for security reasons. 
Checked locally and seems to keep the app going the same way

https://github.com/ubyssey/dispatch/network/alert/setup.py/django/open
