### PR TITLE
Make image, subsection, article & video authors required

### DIFF
--- a/dispatch/api/validators.py
+++ b/dispatch/api/validators.py
@@ -101,9 +101,8 @@ class AuthorValidator(object):
         for author in data:
             if 'person' not in author:
                 raise ValidationError('An author must contain a person.')
-            if 'type' in author and not isinstance(author['type'], str):
-                # If type is defined, it should be a string
-                raise ValidationError('The author type must be a string.')
+            if 'type' not in author:
+                raise ValidationError('An author must contain a type.')
 
 def TemplateValidator(template, template_data, tags, subsection_id):
 

--- a/dispatch/api/validators.py
+++ b/dispatch/api/validators.py
@@ -98,11 +98,22 @@ class AuthorValidator(object):
             # Convert single instance to a list
             data = [data]
 
+        AUTHOR_TYPES = {'author', 'photographer', 'illustrator', 'videographer'}
+
         for author in data:
             if 'person' not in author:
                 raise ValidationError('An author must contain a person.')
-            if 'type' not in author:
-                raise ValidationError('An author must contain a type.')
+            if 'type' in author:
+                if isinstance(author, dict):
+                    if not isinstance(author['type'], str) or author['type'].lower() not in AUTHOR_TYPES:
+                        raise ValidationError('The author type must be a string, matching a predefined type.')
+                elif isinstance(author, str):
+                    tokens = author.split('"')
+                    for i in range(0, len(tokens)):
+                        if 5 + 6 * i < len(tokens):
+                            author_type = tokens[5 + 6 * i]
+                            if author_type.lower() not in AUTHOR_TYPES:
+                                raise ValidationError('The author type must be a string, matching a predefined type.')
 
 def TemplateValidator(template, template_data, tags, subsection_id):
 

--- a/dispatch/modules/auth/managers.py
+++ b/dispatch/modules/auth/managers.py
@@ -15,9 +15,6 @@ class UserManager(BaseUserManager):
         if not self.is_valid_password(password):
             raise ValueError('Password is invalid')
 
-        if not person:
-            raise ValueError('User must have a valid person')
-
         user = self.model(email=email, is_active=is_active, is_superuser=is_superuser)
         user.set_password(password)
         

--- a/dispatch/static/manager/src/js/components/GalleryEditor/DragDropContext.js
+++ b/dispatch/static/manager/src/js/components/GalleryEditor/DragDropContext.js
@@ -1,0 +1,3 @@
+import HTML5Backend from 'react-dnd-html5-backend'
+import { DragDropContext } from 'react-dnd'
+export default DragDropContext(HTML5Backend)

--- a/dispatch/static/manager/src/js/components/GalleryEditor/GalleryForm.js
+++ b/dispatch/static/manager/src/js/components/GalleryEditor/GalleryForm.js
@@ -1,8 +1,7 @@
 import R from 'ramda'
 import React from 'react'
 import { connect } from 'react-redux'
-import { DragDropContext } from 'react-dnd'
-import HTML5Backend from 'react-dnd-html5-backend'
+import DragDropContext from './DragDropContext'
 import Measure from 'react-measure'
 import autobind from 'class-autobind'
 
@@ -307,10 +306,9 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-
 const GalleryForm = connect(
   mapStateToProps,
   mapDispatchToProps
-)(DragDropContext(HTML5Backend)(GalleryFormComponent))
+)(DragDropContext(GalleryFormComponent))
 
 export default GalleryForm

--- a/dispatch/static/manager/src/js/components/ImageEditor/ImageForm.js
+++ b/dispatch/static/manager/src/js/components/ImageEditor/ImageForm.js
@@ -45,6 +45,7 @@ export default class ImageForm extends React.Component {
           <AuthorSelectInput
             value={this.props.listItem.authors}
             update={authors => this.props.update('authors', authors)}
+            authorErrors={this.props.authorErrors}
             defaultAuthorType={AuthorSelectInput.PHOTOGRAPHER} />
         </Form.Input>
 

--- a/dispatch/static/manager/src/js/components/ItemEditor/index.js
+++ b/dispatch/static/manager/src/js/components/ItemEditor/index.js
@@ -11,6 +11,14 @@ const NEW_LISTITEM_ID = 'new'
 
 class ItemEditor extends React.Component {
 
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      noAuthorError: null
+    }
+  }
+
   componentDidMount() {
     if (this.props.isNew) {
       // Create empty listItem
@@ -53,19 +61,26 @@ class ItemEditor extends React.Component {
   }
 
   saveListItem() {
+    const listItem = this.getListItem()
+    if (listItem.authors && !listItem.authors.length) {
+      this.setState({ noAuthorError: 'This field is required.' })
+      return
+    }
+
     if (this.props.isNew) {
-      this.props.createListItem(this.props.token, this.getListItem())
+      this.props.createListItem(this.props.token, listItem)
     } else {
       this.props.saveListItem(
         this.props.token,
         this.props.itemId,
-        this.getListItem()
+        listItem
       )
     }
   }
 
   handleUpdate(field, value) {
     this.props.setListItem(R.assoc(field, value, this.getListItem()))
+    if(field == 'authors' && value.length) { this.setState({ noAuthorError: null }) }
   }
 
   render() {
@@ -94,6 +109,7 @@ class ItemEditor extends React.Component {
             <this.props.form
               listItem={listItem}
               errors={this.props.listItem ? this.props.listItem.errors : {}}
+              authorErrors={this.state.noAuthorError}
               update={(field, value) => this.handleUpdate(field, value)}
               settings={this.props.settings ? this.props.settings : {}} />
           </div>

--- a/dispatch/static/manager/src/js/components/SubsectionEditor/SubsectionForm.js
+++ b/dispatch/static/manager/src/js/components/SubsectionEditor/SubsectionForm.js
@@ -73,6 +73,7 @@ export default function SubsectionForm(props) {
         error={props.errors.author_ids}>
         <AuthorSelectInput
           value={props.listItem.authors || []}
+          authorErrors={props.authorErrors}
           update={authors => props.update('authors', authors)} />
       </Form.Input>
 

--- a/dispatch/static/manager/src/js/components/VideoEditor/VideoForm.js
+++ b/dispatch/static/manager/src/js/components/VideoEditor/VideoForm.js
@@ -37,6 +37,7 @@ export default function VideoForm(props) {
         <AuthorSelectInput
           value={props.listItem.authors ? props.listItem.authors: []}
           update={authors => props.update('authors', authors)} 
+          authorErrors={props.authorErrors}
           defaultAuthorType={AuthorSelectInput.VIDEOGRAPHER} />
       </Form.Input>
 

--- a/dispatch/static/manager/src/js/components/inputs/SortableList/index.js
+++ b/dispatch/static/manager/src/js/components/inputs/SortableList/index.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import R from 'ramda'
 import PropTypes from 'prop-types'
-import { DragDropContext } from 'react-dnd'
-import HTML5Backend from 'react-dnd-html5-backend'
-
+import DragDropContext from '../../GalleryEditor/DragDropContext'
 import Item from './Item'
 
 require('../../../../styles/components/sortable_list.scss')
@@ -55,4 +53,4 @@ SortableList.defaultProps = {
   inline: false
 }
 
-export default DragDropContext(HTML5Backend)(SortableList)
+export default DragDropContext(SortableList)

--- a/dispatch/static/manager/src/js/components/inputs/selects/AuthorSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/selects/AuthorSelectInput.js
@@ -36,11 +36,14 @@ class AuthorSelectInputComponent extends React.Component {
   }
 
   render() {
-    const value = this.props.value
-      .map(author => author.person)
-
-    const extraFields = this.props.value
+    let value = []
+    let extraFields = []
+    
+    if(this.props.value){
+      value = this.props.value.map(author => author.person)
+      extraFields = this.props.value
       .reduce((fields, author) => R.assoc(author.person, author.type, fields), {})
+    }
 
     return (
       <ItemSelectInput
@@ -55,7 +58,8 @@ class AuthorSelectInputComponent extends React.Component {
         fetchResults={(query) => this.listPersons(query)}
         extraFieldOptions={AUTHOR_TYPES}
         attribute='full_name'
-        editMessage={this.props.value.length ? 'Edit authors' : 'Add authors'} />
+        errors={this.props.authorErrors} 
+        editMessage={this.props.value && this.props.value.length ? 'Edit authors' : 'Add authors'} />
     )
   }
 }

--- a/dispatch/static/manager/src/js/components/inputs/selects/ItemSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/selects/ItemSelectInput.js
@@ -251,6 +251,12 @@ class ItemSelectInput extends React.Component {
       </Tag>
     )
 
+    const error = (
+      <span className='c-form__input__error bp3-tag bp3-intent-danger'>
+        {Array.isArray(this.props.errors) ? this.props.errors.join(' ') : this.props.errors}
+      </span>
+    )  
+
     return (
       <div
         className={`c-input c-input--item-select ${this.props.className}`}>
@@ -261,6 +267,7 @@ class ItemSelectInput extends React.Component {
           inline={this.props.inline}>
           {this.props.tag ? tagButton : Button}
         </Dropdown>
+        {this.props.errors && error}
       </div>
     )
   }

--- a/dispatch/static/manager/src/js/components/inputs/selects/TagSelectInput.js
+++ b/dispatch/static/manager/src/js/components/inputs/selects/TagSelectInput.js
@@ -27,7 +27,7 @@ class TagSelectInputComponent extends React.Component {
         fetchResults={(query) => this.listTags(query)}
         create={(name, cb) => this.props.createTag(this.props.token, { name }, cb)}
         attribute='name'
-        editMessage={this.props.value.length ? 'Edit tags' : 'Add tags'} />
+        editMessage={this.props.value && this.props.value.length ? 'Edit tags' : 'Add tags'} />
     )
   }
 

--- a/dispatch/static/manager/src/js/components/modals/ImageManager/ImagePanel.js
+++ b/dispatch/static/manager/src/js/components/modals/ImageManager/ImagePanel.js
@@ -16,14 +16,14 @@ export default function ImagePanel(props) {
       <div className='c-image-panel__header'>
         <Button
           intent={Intent.SUCCESS}
-          onClick={() => props.save()}>Update</Button>
+          onClick={() => {props.save()}}>{props.successBtnName || 'Update'}</Button>
         <Button
           intent={Intent.DANGER}
-          onClick={() => props.delete()}>Delete</Button>
+          onClick={() => props.delete()}>{props.dangerBtnName || 'Delete'}</Button>
       </div>
       <div className='c-image-panel__image'>
-        <img className='c-image-panel__image__img' src={props.image.url_medium} />
-        <div className='c-image-panel__image__filename'>{props.image.filename}</div>
+        <img className='c-image-panel__image__img' src={props.image.url_medium? props.image.url_medium : props.image.img.preview} />
+        <div className='c-image-panel__image__filename'>{props.image.filename? props.image.filename: props.image.img.name}</div>
       </div>
       <form className='c-image-panel__form'>
         <Form.Input label='Title'>
@@ -35,7 +35,8 @@ export default function ImagePanel(props) {
         <Form.Input label='Photographers'>
           <AuthorSelectInput
             value={props.image.authors}
-            update={authors => props.update('authors', authors)}
+            update={authors => {props.update('authors', authors)}}
+            authorErrors={props.authorErrors}
             defaultAuthorType={AuthorSelectInput.PHOTOGRAPHER} />
         </Form.Input>
         <Form.Input label='Tags'>

--- a/dispatch/static/manager/src/styles/components/image_manager.scss
+++ b/dispatch/static/manager/src/styles/components/image_manager.scss
@@ -1,4 +1,5 @@
 @import '../utilities/colors';
+@import '../utilities/variables';
 
 // Component: ImageManager
 .c-image-manager {
@@ -71,6 +72,26 @@ $image-manager-footer-box-shadow: rgba(0,0,0,0.05) 0px -1px 1px;
       margin-right: 0;
     }
   }
+}
+
+.c-modal-body {
+  background-color: $color-white;
+  margin: 15% auto; /* 15% from the top and centered */
+  padding: 20px;
+  border: 1px solid $color-border-gray;
+  width: 80%; /* Could be more or less, depending on screen size */
+}
+
+.c-modal-container-scrollable {
+  position: fixed; /* Stay in place */
+  z-index: $z-index-3; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: $color-bg-black; /* Fallback color */
+  background-color: $color-bg-black-opacity; /* Black w/ opacity */
 }
 
 .c-image-manager__body {

--- a/dispatch/static/manager/src/styles/components/modal_container.scss
+++ b/dispatch/static/manager/src/styles/components/modal_container.scss
@@ -12,7 +12,7 @@
   left: 0;
 
   // Background
-  background: rgba(0, 0, 0, 0.5);
+  background: $color-bg-black-opacity;
 
   // Extras
   z-index: $z-index-3;
@@ -35,7 +35,7 @@
 
   // Background
   background: $color-white;
-  box-shadow: rgba(0,0,0,0.5) 0px 0px 5px;
+  box-shadow: $color-bg-black-opacity 0px 0px 5px;
 
   // Extras
   z-index: $z-index-4;

--- a/dispatch/static/manager/src/styles/utilities/_colors.scss
+++ b/dispatch/static/manager/src/styles/utilities/_colors.scss
@@ -19,6 +19,8 @@ $color-border-blue:      #51a7e8;
 $color-bg-gray:          #eeeeee;
 $color-bg-gray-light:    #fcfcfc;
 $color-bg-gray-dark:     #dddddd;
+$color-bg-black:         rgb(0,0,0);
+$color-bg-black-opacity: rgba(0,0,0,0.5);
 $color-dispatch-header-hover: rgba(138, 155, 168, 0.15);
 
 // Inputs

--- a/dispatch/tests/test_api_articles.py
+++ b/dispatch/tests/test_api_articles.py
@@ -246,6 +246,10 @@ class ArticlesTests(DispatchAPITestCase, DispatchMediaTestMixin):
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+        data['author_ids'][0]['type'] = 'article author'
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_update_article_tags(self):
         """Should be able to update and remove article tags"""
 
@@ -736,13 +740,7 @@ class ArticlesTests(DispatchAPITestCase, DispatchMediaTestMixin):
         """Ensure that a featured image can be set"""
 
         article = DispatchTestHelpers.create_article(self.client)
-
-        url = reverse('api-images-list')
-
-        image_file = 'test_image_a.jpg'
-
-        with open(self.get_input_file(image_file), 'rb') as test_image:
-            image = self.client.post(url, { 'img': test_image }, format='multipart')
+        image = DispatchTestHelpers.create_image(self.client)
 
         data = {
             'featured_image':   {
@@ -760,13 +758,6 @@ class ArticlesTests(DispatchAPITestCase, DispatchMediaTestMixin):
         """Ensure that there must have an image_id in order to set a featured image"""
 
         article = DispatchTestHelpers.create_article(self.client)
-
-        url = reverse('api-images-list')
-
-        image_file = 'test_image_a.jpg'
-
-        with open(self.get_input_file(image_file), 'rb') as test_image:
-            image = self.client.post(url, { 'img': test_image }, format='multipart')
 
         data = {
             'featured_image':   {
@@ -792,14 +783,8 @@ class ArticlesTests(DispatchAPITestCase, DispatchMediaTestMixin):
         """Ensure that a featured image can be removed"""
 
         article = DispatchTestHelpers.create_article(self.client)
-
-        url = reverse('api-images-list')
-
-        image_file = 'test_image_a.jpg'
-
-        with open(self.get_input_file(image_file), 'rb') as test_image:
-            image = self.client.post(url, { 'img': test_image }, format='multipart')
-
+        image = DispatchTestHelpers.create_image(self.client)
+        
         data = {
             'featured_image':   {
                 'image_id': image.data['id']

--- a/dispatch/tests/test_api_pages.py
+++ b/dispatch/tests/test_api_pages.py
@@ -231,13 +231,8 @@ class PagesTest(DispatchAPITestCase, DispatchMediaTestMixin):
         """Ensure that a featured image can be set"""
 
         page = DispatchTestHelpers.create_page(self.client)
-        
-        url = reverse('api-images-list')
-        
-        image_file = 'test_image_a.jpg'
 
-        with open(self.get_input_file(image_file), 'rb') as test_image:
-            image = self.client.post(url, { 'img': test_image }, format='multipart')
+        image = DispatchTestHelpers.create_image(self.client)
 
         data = {
             'featured_image':   {
@@ -256,12 +251,7 @@ class PagesTest(DispatchAPITestCase, DispatchMediaTestMixin):
 
         page = DispatchTestHelpers.create_page(self.client)
         
-        url = reverse('api-images-list')
-        
-        image_file = 'test_image_a.jpg'
-
-        with open(self.get_input_file(image_file), 'rb') as test_image:
-            image = self.client.post(url, { 'img': test_image }, format='multipart')
+        image = DispatchTestHelpers.create_image(self.client)
 
         data = {
             'featured_image':   {

--- a/dispatch/tests/test_api_persons.py
+++ b/dispatch/tests/test_api_persons.py
@@ -137,7 +137,7 @@ class PersonsTests(DispatchAPITestCase, DispatchMediaTestMixin):
         )
         response2 = DispatchTestHelpers.create_person(
             self.client,
-            full_name='Test Person 2',
+            full_name='Test Person 20',
             slug='test-person'
         )
 

--- a/dispatch/tests/test_api_users.py
+++ b/dispatch/tests/test_api_users.py
@@ -21,6 +21,8 @@ TEST_USER_FULL_NAME_4 = 'John Doe Fourth'
 TEST_USER_SLUG_4 = 'john-doe-fourth'
 TEST_USER_FULL_NAME_5 = 'John Doe Fifth'
 TEST_USER_SLUG_5 = 'john-doe-fifth'
+TEST_USER_FULL_NAME_6 = 'John Doe Sixth'
+TEST_USER_SLUG_6 = 'john-doe-sixth'
 
 class UserTests(DispatchAPITestCase):
     """A class to test the user API methods"""
@@ -45,7 +47,10 @@ class UserTests(DispatchAPITestCase):
 
         url = reverse('api-users-list')
 
-        person_id = DispatchTestHelpers.create_person(self.client, full_name=TEST_USER_FULL_NAME, slug=TEST_USER_SLUG).data['id']
+        person_id = DispatchTestHelpers.create_person(self.client, 
+            full_name=TEST_USER_FULL_NAME, 
+            slug=TEST_USER_SLUG).data['id']
+
         data = {
             'email' : TEST_USER_EMAIL,
             'person' : person_id,
@@ -57,7 +62,6 @@ class UserTests(DispatchAPITestCase):
         response = self.client.post(url, data, format='json')
 
         user = User.objects.get(person=person_id)
-
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 


### PR DESCRIPTION
## What problem does this PR solve?

This PR solves the issue of having images, subsections, videos, and articles with no authors. Now when any of these will be uploaded they will contain at least one author.

## How did you fix the problem?

Added a modal that shows up whenever a new image is uploaded. It supports uploading multiple images at the same time. It displays an error message when the user tries to save the image without adding authors. The validation is done both at the backend (a Postman POST request with no authors will fail) and frontend (clicking on Save button when there no authors will display an error and won't send the POST request). I added frontend validation because it is faster and because there were some issues with using only the backend validation. For example, both the editImagePanel and the uploadImagePanel in index.js (from ImageManager folder) are using state.app.images.single.errors.author_ids as the source of the no-author-error, and hence if the user runs into an error in the editImagePanel, and they don't clear it and hit upload image, the error will show up in the upload modal, which is not a good user experience. 