### PR TITLE
Add video creation date picker in the video form in dispatch

### DIFF
--- a/dispatch/modules/content/models.py
+++ b/dispatch/modules/content/models.py
@@ -459,7 +459,7 @@ class Video(Model, AuthorMixin):
     authors = ManyToManyField(Author, related_name='video_authors')
     tags = ManyToManyField('Tag')
 
-    created_at = DateTimeField(auto_now_add=True)
+    created_at = DateTimeField(default=timezone.now)
     updated_at = DateTimeField(auto_now=True)
 
     AuthorModel = Author

--- a/dispatch/static/manager/src/js/components/VideoEditor/VideoForm.js
+++ b/dispatch/static/manager/src/js/components/VideoEditor/VideoForm.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { TextInput } from '../inputs'
+import { TextInput, DateTimeInput } from '../inputs'
 import AuthorSelectInput from '../inputs/selects/AuthorSelectInput'
 import TagSelectInput from '../inputs/selects/TagSelectInput'
 
@@ -48,7 +48,15 @@ export default function VideoForm(props) {
           value={props.listItem.tags ? props.listItem.tags: []}
           update={tags => props.update('tags', tags)} />
       </Form.Input>
-        
+
+      <Form.Input
+        label='Created at'
+        error={props.errors.created_at}>
+        <DateTimeInput
+          value={props.listItem.created_at}
+          onChange={dt => props.update('created_at', dt)} />
+      </Form.Input>
+      
       {props.listItem.url && 
         <div className='c-image-panel-image-page'>
           <div className='c-image-panel__image'>


### PR DESCRIPTION
## What problem does this PR solve?

This PR solves the issue of not having a way to organize our videos on the front page and in the video section. Now the video editors can update the creation date for existing videos or set the creation date for new videos in order to make them appear in a certain order on the website.

## How did you fix the problem?

I changed the created_at field from Video model from models.py, and I changed the VideoForm so as to include the DateTimeInput for created_at field.